### PR TITLE
feat(obsync): CouchDB image for Obsidian Self-hosted LiveSync

### DIFF
--- a/apps/obsync/Dockerfile
+++ b/apps/obsync/Dockerfile
@@ -9,6 +9,7 @@ FROM docker.io/couchdb:${VERSION}
 
 ARG DENO_VERSION
 ARG OBSIDIAN_LIVESYNC_REF
+ARG TARGETARCH
 
 USER root
 
@@ -19,8 +20,14 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Deno (static binary) — needed only by the setup-uri command. Pre-cache
-# the encryption npm dep so runtime never needs network access.
-RUN curl -fsSL "https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip" -o /tmp/deno.zip \
+# the encryption npm dep so runtime never needs network access. Pick the
+# binary matching the build platform (amd64 → x86_64-…, arm64 → aarch64-…).
+RUN case "${TARGETARCH}" in \
+        amd64) deno_arch=x86_64-unknown-linux-gnu ;; \
+        arm64) deno_arch=aarch64-unknown-linux-gnu ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-${deno_arch}.zip" -o /tmp/deno.zip \
     && unzip /tmp/deno.zip -d /usr/local/bin \
     && chmod +x /usr/local/bin/deno \
     && rm /tmp/deno.zip \

--- a/apps/obsync/Dockerfile
+++ b/apps/obsync/Dockerfile
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1
+# check=skip=InvalidDefaultArgInFrom
+
+# CouchDB tuned for Obsidian Self-hosted LiveSync, with declarative
+# user / shared-vault provisioning at boot and a one-shot CLI for
+# generating obsidian://setuplivesync setup URIs.
+ARG VERSION
+FROM docker.io/couchdb:${VERSION}
+
+ARG DENO_VERSION
+ARG OBSIDIAN_LIVESYNC_REF
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl jq unzip xxd \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Deno (static binary) — needed only by the setup-uri command. Pre-cache
+# the encryption npm dep so runtime never needs network access.
+RUN curl -fsSL "https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip" -o /tmp/deno.zip \
+    && unzip /tmp/deno.zip -d /usr/local/bin \
+    && chmod +x /usr/local/bin/deno \
+    && rm /tmp/deno.zip \
+    && deno --version
+
+# Vendor the upstream LiveSync setup URI generator at build time, and
+# pre-cache its npm/jsr deps so runtime never needs network.
+RUN mkdir -p /opt/obsync \
+    && curl -fsSL "https://raw.githubusercontent.com/vrtmrz/obsidian-livesync/${OBSIDIAN_LIVESYNC_REF}/utils/flyio/generate_setupuri.ts" \
+        -o /opt/obsync/generate_setupuri.ts \
+    && deno cache --allow-import /opt/obsync/generate_setupuri.ts
+
+# Bake LiveSync-tuned CouchDB config into the image.
+COPY local.ini /opt/couchdb/etc/local.ini
+
+# Image scripts.
+COPY entrypoint.sh           /usr/local/bin/obsync-entrypoint.sh
+COPY scripts/provision.sh    /opt/obsync/provision.sh
+COPY scripts/obsync          /usr/local/bin/obsync
+RUN chmod +x \
+    /usr/local/bin/obsync-entrypoint.sh \
+    /opt/obsync/provision.sh \
+    /usr/local/bin/obsync
+
+# Run as the existing couchdb user (uid 5984) so the image's chown-on-start
+# block is skipped and read-only mounts work.
+USER 5984:5984
+
+# tini is already present in the upstream image and on PATH.
+ENTRYPOINT ["tini", "--", "/usr/local/bin/obsync-entrypoint.sh"]
+CMD ["/opt/couchdb/bin/couchdb"]

--- a/apps/obsync/docker-bake.hcl
+++ b/apps/obsync/docker-bake.hcl
@@ -1,0 +1,51 @@
+target "docker-metadata-action" {}
+
+variable "VERSION" {
+  // renovate: datasource=docker depName=couchdb versioning=docker
+  default = "3.5.1"
+}
+
+variable "DENO_VERSION" {
+  // renovate: datasource=github-releases depName=denoland/deno extractVersion=^v(?<version>.*)$
+  default = "2.1.4"
+}
+
+variable "OBSIDIAN_LIVESYNC_REF" {
+  # Pin to a specific commit/tag once we want reproducibility.
+  # Tracking 'main' for now — the upstream generate_setupuri.ts changes
+  # rarely and is small enough to manually audit on bumps.
+  // renovate: datasource=github-tags depName=vrtmrz/obsidian-livesync
+  default = "main"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/astrateam-net/containers"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION               = "${VERSION}"
+    DENO_VERSION          = "${DENO_VERSION}"
+    OBSIDIAN_LIVESYNC_REF = "${OBSIDIAN_LIVESYNC_REF}"
+  }
+  labels = {
+    "org.opencontainers.image.source"      = "${SOURCE}"
+    "org.opencontainers.image.title"       = "obsync — CouchDB for Obsidian LiveSync"
+    "org.opencontainers.image.description" = "CouchDB ${VERSION} with declarative provisioning + setup URI CLI for Obsidian Self-hosted LiveSync"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output   = ["type=docker"]
+}
+
+target "image-all" {
+  inherits  = ["image"]
+  platforms = ["linux/amd64", "linux/arm64"]
+}

--- a/apps/obsync/entrypoint.sh
+++ b/apps/obsync/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# obsync image entrypoint: bridges Docker swarm secrets to env vars consumed
+# by the upstream couchdb entrypoint, optionally backgrounds the provisioner,
+# then hands off to the upstream entrypoint with the original CMD.
+set -eu
+
+if [ -f /run/secrets/obsync_admin_user ]; then
+    export COUCHDB_USER=$(cat /run/secrets/obsync_admin_user)
+fi
+if [ -f /run/secrets/obsync_admin_password ]; then
+    export COUCHDB_PASSWORD=$(cat /run/secrets/obsync_admin_password)
+fi
+if [ -f /run/secrets/obsync_chttpd_secret ]; then
+    export COUCHDB_SECRET=$(cat /run/secrets/obsync_chttpd_secret)
+fi
+
+# If a provisioning config is mounted, fork the provisioner so it can run
+# in parallel with CouchDB startup. It polls /_up before doing any work.
+if [ -f /run/secrets/obsync_provisioning_config ]; then
+    /opt/obsync/provision.sh &
+fi
+
+# Hand off to the upstream couchdb entrypoint with the original CMD.
+exec /usr/local/bin/docker-entrypoint.sh "$@"

--- a/apps/obsync/local.ini
+++ b/apps/obsync/local.ini
@@ -1,0 +1,49 @@
+; CouchDB config tuned for Obsidian Self-hosted LiveSync.
+; Baked into the image at /opt/couchdb/etc/local.ini.
+; Admin user, [chttpd_auth] secret, and [admins] section are written to
+; /opt/couchdb/etc/local.d/docker.ini by the official entrypoint from
+; COUCHDB_USER / COUCHDB_PASSWORD / COUCHDB_SECRET env vars.
+
+[couchdb]
+single_node = true
+; max_document_size caps ONE document, not file size. LiveSync chunks every file
+; into ~50 KB docs, so this only bites if chunks somehow grow huge. 256 MiB is
+; well above any chunked workload and safely below Erlang VM memory limits.
+; Actual file-size cap is plugin-side syncMaxSizeInMB (set per device).
+max_document_size = 268435456
+max_dbs_open = 500
+
+[cluster]
+; Single-node deployment: default n=3 makes system DB creation fail.
+n = 1
+q = 2
+
+[couch_peruser]
+enable = true
+delete_dbs = false
+
+[chttpd]
+; All requests require valid user EXCEPT /_up (so the container healthcheck
+; works without baking creds into the compose file). Per CouchDB config/auth.rst.
+require_valid_user_except_for_up = true
+max_http_request_size = 4294967296
+bind_address = 0.0.0.0
+port = 5984
+
+[httpd]
+WWW-Authenticate = Basic realm="couchdb"
+enable_cors = true
+
+[chttpd_cors]
+credentials = true
+origins = app://obsidian.md,capacitor://localhost,http://localhost
+
+[cors]
+credentials = true
+origins = app://obsidian.md,capacitor://localhost,http://localhost
+methods = GET, PUT, POST, HEAD, DELETE
+headers = accept, authorization, content-type, origin, referer
+
+[log]
+writer = stderr
+level = info

--- a/apps/obsync/scripts/obsync
+++ b/apps/obsync/scripts/obsync
@@ -1,0 +1,166 @@
+#!/bin/bash
+# obsync — operator CLI for the obsync image.
+# Usage: obsync <subcommand> [args]
+#
+# Designed to run via `docker exec obsync_app obsync <...>`. Reads admin
+# credentials from /run/secrets and the provisioning config (users, vaults,
+# passphrases) from the same source the boot provisioner uses.
+
+set -eu
+
+URL=http://localhost:5984
+CONFIG=/run/secrets/obsync_provisioning_config
+
+# Public hostname embedded in setup URIs. Set in compose:
+#   environment:
+#     - OBSYNC_PUBLIC_URL=https://obsync.example.com
+PUBLIC_URL=${OBSYNC_PUBLIC_URL:-https://localhost:5984}
+
+die()  { echo "ERROR: $*" >&2; exit 1; }
+need() { [ -f "$CONFIG" ] || die "provisioning config not mounted at $CONFIG"; }
+
+# Lazy admin-cred load — only read when a subcommand needs them. Lets `help`
+# and similar work in environments without secrets mounted (e.g. CI tests).
+load_admin_creds() {
+    [ -f /run/secrets/obsync_admin_user ] || die "admin user secret not mounted"
+    [ -f /run/secrets/obsync_admin_password ] || die "admin password secret not mounted"
+    ADMIN_USER=$(cat /run/secrets/obsync_admin_user)
+    ADMIN_PASS=$(cat /run/secrets/obsync_admin_password)
+}
+
+userdb_name() {
+    # CouchDB couch_peruser convention: userdb-<hex(utf8(name))>
+    printf 'userdb-%s' "$(printf '%s' "$1" | xxd -p | tr -d '\n')"
+}
+
+cmd_setup_uri() {
+    need
+    local user=${1:-}; local vault=${2:-}
+    [ -z "$user" ] && die "usage: obsync setup-uri <user> [shared-vault]"
+
+    local pw passphrase db
+    pw=$(jq -r --arg u "$user" '.users[$u].password // empty' "$CONFIG")
+    [ -z "$pw" ] && die "user '$user' not found in provisioning config"
+
+    if [ -z "$vault" ]; then
+        db=$(userdb_name "$user")
+        passphrase=$(jq -r --arg u "$user" '.users[$u].e2ee_passphrase // empty' "$CONFIG")
+        [ -z "$passphrase" ] && die "user '$user' has no e2ee_passphrase set"
+        echo "=== private vault: $user → $db ==="
+    else
+        db=$vault
+        passphrase=$(jq -r --arg v "$vault" '.shared_vaults[$v].e2ee_passphrase // empty' "$CONFIG")
+        [ -z "$passphrase" ] && die "shared vault '$vault' not in provisioning config"
+        if ! jq -e --arg u "$user" --arg v "$vault" \
+                '.shared_vaults[$v].members | index($u) != null' "$CONFIG" >/dev/null
+        then
+            die "user '$user' is not a member of '$vault' (per provisioning config)"
+        fi
+        echo "=== shared vault: $user → $db ==="
+    fi
+
+    echo
+    hostname="$PUBLIC_URL" username="$user" password="$pw" \
+        database="$db" passphrase="$passphrase" \
+        deno run -A --quiet /opt/obsync/generate_setupuri.ts
+    echo
+    echo "Hand the URI and the uri_passphrase to the user over DIFFERENT"
+    echo "channels (URI via clipboard/email, passphrase typed/spoken)."
+}
+
+cmd_user_list() {
+    need
+    local users
+    users=$(jq -r '(.users // {}) | keys[]' "$CONFIG")
+    [ -z "$users" ] && { echo "(no users in provisioning config)"; return; }
+    while IFS= read -r u; do
+        local in_vaults
+        in_vaults=$(jq -r --arg u "$u" \
+            '[(.shared_vaults // {}) | to_entries[]
+              | select(.value.members | index($u)) | .key] | join(", ")' \
+            "$CONFIG")
+        if [ -n "$in_vaults" ]; then
+            printf '%-20s  private + %s\n' "$u" "$in_vaults"
+        else
+            printf '%-20s  private only\n' "$u"
+        fi
+    done <<< "$users"
+}
+
+cmd_vault_list() {
+    need
+    jq -r '(.shared_vaults // {}) | to_entries[]
+           | "\(.key)\t\(.value.members | join(", "))"' "$CONFIG" \
+    | while IFS=$'\t' read -r v m; do
+        printf '%-30s  members: %s\n' "$v" "${m:-<none>}"
+    done
+}
+
+cmd_user_purge() {
+    local user=${1:-}
+    [ -z "$user" ] && die "usage: obsync user-purge <user>"
+    load_admin_creds
+
+    printf 'DELETE user %s AND their userdb? [type "yes" to confirm]: ' "$user"
+    read -r confirm
+    [ "$confirm" = yes ] || die "aborted"
+
+    local rev
+    rev=$(curl -sS -u "$ADMIN_USER:$ADMIN_PASS" \
+        "$URL/_users/org.couchdb.user:$user" | jq -r '._rev // empty')
+    if [ -n "$rev" ]; then
+        curl -sf -u "$ADMIN_USER:$ADMIN_PASS" -X DELETE \
+            "$URL/_users/org.couchdb.user:$user?rev=$rev" >/dev/null
+        echo "deleted user $user"
+    else
+        echo "user $user not found in /_users (skipping)"
+    fi
+
+    local db; db=$(userdb_name "$user")
+    if curl -sf -u "$ADMIN_USER:$ADMIN_PASS" "$URL/$db" >/dev/null 2>&1; then
+        curl -sf -u "$ADMIN_USER:$ADMIN_PASS" -X DELETE "$URL/$db" >/dev/null
+        echo "deleted database $db"
+    else
+        echo "database $db not found (skipping)"
+    fi
+
+    echo "NOTE: any shared-vault membership remains in those vaults' _security"
+    echo "      docs. Remove the user from topology.yaml + redeploy to clean up."
+}
+
+cmd_provision_now() {
+    /opt/obsync/provision.sh
+}
+
+cmd_help() {
+    cat <<'EOF'
+obsync — Obsidian LiveSync CouchDB ops CLI
+
+Usage: obsync <subcommand> [args]
+
+  setup-uri <user>                  Generate setup URI for user's private vault
+  setup-uri <user> <shared-vault>   Generate setup URI for a shared vault
+  user-list                         List managed users + their vault memberships
+  vault-list                        List shared vaults + members
+  user-purge <user>                 Delete user account + private DB (interactive)
+  provision-now                     Re-run the boot provisioner immediately
+  help                              This message
+
+The CLI reads admin creds from /run/secrets/obsync_admin_*  and the
+provisioning config (users, vaults, passphrases) from
+/run/secrets/obsync_provisioning_config. Set OBSYNC_PUBLIC_URL in compose
+to the public hostname embedded in setup URIs.
+EOF
+}
+
+cmd=${1:-help}
+shift || true
+case "$cmd" in
+    setup-uri)     cmd_setup_uri "$@" ;;
+    user-list)     cmd_user_list ;;
+    vault-list)    cmd_vault_list ;;
+    user-purge)    cmd_user_purge "$@" ;;
+    provision-now) cmd_provision_now ;;
+    help|-h|--help) cmd_help ;;
+    *) echo "unknown subcommand: $cmd" >&2; cmd_help; exit 2 ;;
+esac

--- a/apps/obsync/scripts/provision.sh
+++ b/apps/obsync/scripts/provision.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Boot-time provisioner. Reads a JSON provisioning config from a Docker swarm
+# secret and ensures CouchDB users, shared databases, and _security membership
+# match. Idempotent — safe to run on every container start.
+#
+# The config secret JSON shape:
+#   {
+#     "users": {
+#       "alice": { "password": "...", "e2ee_passphrase": "..." },
+#       ...
+#     },
+#     "shared_vaults": {
+#       "team-engineering": { "members": ["alice","bob"], "e2ee_passphrase": "..." },
+#       ...
+#     }
+#   }
+#
+# E2EE passphrases are not used by CouchDB itself — they're handed to the
+# `obsync setup-uri` command later. They live in the same config so the
+# image has a single source of truth.
+
+set -eu
+
+LOG_PREFIX="[provision]"
+log() { echo "${LOG_PREFIX} $*"; }
+
+ADMIN_USER=$(cat /run/secrets/obsync_admin_user)
+ADMIN_PASS=$(cat /run/secrets/obsync_admin_password)
+URL=http://localhost:5984
+CONFIG=/run/secrets/obsync_provisioning_config
+
+if [ ! -f "$CONFIG" ]; then
+    log "no provisioning config mounted at $CONFIG; skipping"
+    exit 0
+fi
+
+# Wait up to 90s for CouchDB to be reachable. /_up is exempt from auth.
+log "waiting for CouchDB to be ready..."
+for _ in $(seq 1 90); do
+    if curl -fsS "$URL/_up" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+if ! curl -fsS "$URL/_up" >/dev/null 2>&1; then
+    log "FATAL: CouchDB did not respond to /_up within 90s; aborting"
+    exit 1
+fi
+log "CouchDB ready"
+
+# 1. Ensure system databases exist (idempotent).
+for db in _users _replicator _global_changes; do
+    code=$(curl -s -o /dev/null -w '%{http_code}' \
+        -u "$ADMIN_USER:$ADMIN_PASS" "$URL/$db")
+    if [ "$code" = "404" ]; then
+        log "creating system db $db"
+        curl -sf -u "$ADMIN_USER:$ADMIN_PASS" -X PUT "$URL/$db" >/dev/null \
+            || log "WARN: PUT /$db failed"
+    fi
+done
+
+# 2. Ensure each managed user exists / has the right password.
+#    The presence of `_rev` distinguishes update from create. CouchDB hashes
+#    the plaintext on first auth and rewrites the doc — that's fine, our PUT
+#    just provides the canonical password each time.
+jq -r '(.users // {}) | to_entries[] | "\(.key)\t\(.value.password)"' "$CONFIG" \
+| while IFS=$'\t' read -r name password; do
+    [ -z "$name" ] && continue
+    log "ensuring user '$name'"
+    existing=$(curl -sS -u "$ADMIN_USER:$ADMIN_PASS" \
+        "$URL/_users/org.couchdb.user:$name")
+    rev=$(printf '%s' "$existing" | jq -r '._rev // empty')
+
+    if [ -n "$rev" ]; then
+        body=$(jq -nc --arg n "$name" --arg p "$password" --arg r "$rev" \
+            '{_id:("org.couchdb.user:"+$n), _rev:$r, name:$n, password:$p, roles:[], type:"user"}')
+    else
+        body=$(jq -nc --arg n "$name" --arg p "$password" \
+            '{name:$n, password:$p, roles:[], type:"user"}')
+    fi
+
+    code=$(printf '%s' "$body" | curl -s -o /dev/null -w '%{http_code}' \
+        -u "$ADMIN_USER:$ADMIN_PASS" -X PUT \
+        -H 'content-type: application/json' \
+        --data-binary @- "$URL/_users/org.couchdb.user:$name")
+    case "$code" in
+        201|200) ;;
+        409)     log "WARN: rev conflict for $name (will retry next boot)" ;;
+        *)       log "WARN: PUT user $name returned $code" ;;
+    esac
+done
+
+# 3. Ensure each shared vault exists with declared membership.
+jq -r '(.shared_vaults // {}) | to_entries[]
+       | "\(.key)\t\(.value.members | join(","))"' "$CONFIG" \
+| while IFS=$'\t' read -r vault members; do
+    [ -z "$vault" ] && continue
+    log "ensuring shared vault '$vault' with members: ${members:-<none>}"
+
+    code=$(curl -s -o /dev/null -w '%{http_code}' \
+        -u "$ADMIN_USER:$ADMIN_PASS" "$URL/$vault")
+    if [ "$code" = "404" ]; then
+        log "creating db $vault"
+        curl -sf -u "$ADMIN_USER:$ADMIN_PASS" -X PUT "$URL/$vault" >/dev/null \
+            || { log "WARN: PUT /$vault failed"; continue; }
+    fi
+
+    members_json=$(printf '%s' "$members" | jq -Rc 'if . == "" then [] else split(",") end')
+    sec=$(jq -nc --argjson m "$members_json" \
+        '{admins:{names:[],roles:[]}, members:{names:$m,roles:[]}}')
+    printf '%s' "$sec" | curl -sf -u "$ADMIN_USER:$ADMIN_PASS" -X PUT \
+        -H 'content-type: application/json' \
+        --data-binary @- "$URL/$vault/_security" >/dev/null \
+        || log "WARN: PUT /$vault/_security failed"
+done
+
+log "provisioning complete"

--- a/apps/obsync/tests.yaml
+++ b/apps/obsync/tests.yaml
@@ -1,0 +1,66 @@
+---
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "couchdb binary present"
+    command: "/opt/couchdb/bin/couchdb"
+    args: ["-version"]
+    exitCode: 0
+
+  - name: "deno installed"
+    command: "deno"
+    args: ["--version"]
+    exitCode: 0
+
+  - name: "jq installed"
+    command: "jq"
+    args: ["--version"]
+    exitCode: 0
+
+  - name: "curl installed"
+    command: "curl"
+    args: ["--version"]
+    exitCode: 0
+
+  - name: "xxd installed (used to compute userdb-<hex> name)"
+    command: "xxd"
+    args: ["-v"]
+    exitCode: 0
+
+  - name: "obsync CLI prints help"
+    command: "/usr/local/bin/obsync"
+    args: ["help"]
+    exitCode: 0
+
+fileExistenceTests:
+  - name: "baked local.ini"
+    path: /opt/couchdb/etc/local.ini
+    shouldExist: true
+
+  - name: "entrypoint script"
+    path: /usr/local/bin/obsync-entrypoint.sh
+    shouldExist: true
+    permissions: "-rwxr-xr-x"
+
+  - name: "provisioner"
+    path: /opt/obsync/provision.sh
+    shouldExist: true
+    permissions: "-rwxr-xr-x"
+
+  - name: "obsync CLI on PATH"
+    path: /usr/local/bin/obsync
+    shouldExist: true
+    permissions: "-rwxr-xr-x"
+
+  - name: "vendored generate_setupuri.ts"
+    path: /opt/obsync/generate_setupuri.ts
+    shouldExist: true
+
+fileContentTests:
+  - name: "local.ini has couch_peruser enabled"
+    path: /opt/couchdb/etc/local.ini
+    expectedContents: ['enable = true']
+
+  - name: "local.ini has require_valid_user_except_for_up"
+    path: /opt/couchdb/etc/local.ini
+    expectedContents: ['require_valid_user_except_for_up = true']


### PR DESCRIPTION
## Summary
- New custom CouchDB 3.5 image for the AstraTeam swarm's obsync stack
- Declarative boot-time provisioning (users + shared vaults + _security) from one JSON Docker swarm secret
- Operator CLI (`obsync setup-uri / user-list / vault-list / user-purge / provision-now`) — wraps the vendored upstream `generate_setupuri.ts`
- LiveSync-tuned `local.ini` baked into image (couch_peruser, n=1 q=2, CORS, large body sizes, healthcheck-friendly auth)

## Test plan
- [x] `local-build obsync` builds clean
- [x] container-structure-test: 13/13 pass
- [x] Smoke-tested end-to-end with mock secrets:
  - Provisioner created two users + shared vault + _security
  - `obsync user-list` / `vault-list` show declared topology
  - `obsync setup-uri alice` (private) returns valid `obsidian://setuplivesync?...` URI
  - `obsync setup-uri alice team-shared` (shared) returns valid URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)