### PR TITLE
feat(obsync): add JWT for clients + Basic for admin (hybrid auth)

### DIFF
--- a/apps/obsync/Dockerfile
+++ b/apps/obsync/Dockerfile
@@ -9,6 +9,7 @@ FROM docker.io/couchdb:${VERSION}
 
 ARG DENO_VERSION
 ARG OBSIDIAN_LIVESYNC_REF
+ARG TARGETARCH
 
 USER root
 
@@ -19,8 +20,14 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Deno (static binary) — needed only by the setup-uri command. Pre-cache
-# the encryption npm dep so runtime never needs network access.
-RUN curl -fsSL "https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip" -o /tmp/deno.zip \
+# the encryption npm dep so runtime never needs network access. Pick the
+# binary matching the build platform (amd64 → x86_64-…, arm64 → aarch64-…).
+RUN case "${TARGETARCH}" in \
+        amd64) deno_arch=x86_64-unknown-linux-gnu ;; \
+        arm64) deno_arch=aarch64-unknown-linux-gnu ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-${deno_arch}.zip" -o /tmp/deno.zip \
     && unzip /tmp/deno.zip -d /usr/local/bin \
     && chmod +x /usr/local/bin/deno \
     && rm /tmp/deno.zip \

--- a/apps/obsync/Dockerfile
+++ b/apps/obsync/Dockerfile
@@ -8,7 +8,6 @@ ARG VERSION
 FROM docker.io/couchdb:${VERSION}
 
 ARG DENO_VERSION
-ARG OBSIDIAN_LIVESYNC_REF
 ARG TARGETARCH
 
 USER root
@@ -33,24 +32,23 @@ RUN case "${TARGETARCH}" in \
     && rm /tmp/deno.zip \
     && deno --version
 
-# Vendor the upstream LiveSync setup URI generator at build time, and
-# pre-cache its npm/jsr deps so runtime never needs network.
-RUN mkdir -p /opt/obsync \
-    && curl -fsSL "https://raw.githubusercontent.com/vrtmrz/obsidian-livesync/${OBSIDIAN_LIVESYNC_REF}/utils/flyio/generate_setupuri.ts" \
-        -o /opt/obsync/generate_setupuri.ts \
-    && deno cache --allow-import /opt/obsync/generate_setupuri.ts
+RUN mkdir -p /opt/obsync
 
 # Bake LiveSync-tuned CouchDB config into the image.
 COPY local.ini /opt/couchdb/etc/local.ini
 
-# Image scripts.
-COPY entrypoint.sh           /usr/local/bin/obsync-entrypoint.sh
-COPY scripts/provision.sh    /opt/obsync/provision.sh
-COPY scripts/obsync          /usr/local/bin/obsync
+# Image scripts. Custom generate_setupuri.ts (extends upstream with JWT mode)
+# is shipped from this repo rather than fetched at build time, so the URI
+# format stays under our control and reproducible.
+COPY entrypoint.sh                  /usr/local/bin/obsync-entrypoint.sh
+COPY scripts/provision.sh           /opt/obsync/provision.sh
+COPY scripts/obsync                 /usr/local/bin/obsync
+COPY scripts/generate_setupuri.ts   /opt/obsync/generate_setupuri.ts
 RUN chmod +x \
-    /usr/local/bin/obsync-entrypoint.sh \
-    /opt/obsync/provision.sh \
-    /usr/local/bin/obsync
+        /usr/local/bin/obsync-entrypoint.sh \
+        /opt/obsync/provision.sh \
+        /usr/local/bin/obsync \
+    && deno cache --allow-import /opt/obsync/generate_setupuri.ts
 
 # Run as the existing couchdb user (uid 5984) so the image's chown-on-start
 # block is skipped and read-only mounts work.

--- a/apps/obsync/Dockerfile
+++ b/apps/obsync/Dockerfile
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1
+# check=skip=InvalidDefaultArgInFrom
+
+# CouchDB tuned for Obsidian Self-hosted LiveSync, with declarative
+# user / shared-vault provisioning at boot and a one-shot CLI for
+# generating obsidian://setuplivesync setup URIs.
+ARG VERSION
+FROM docker.io/couchdb:${VERSION}
+
+ARG DENO_VERSION
+ARG OBSIDIAN_LIVESYNC_REF
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl jq unzip xxd \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Deno (static binary) — needed only by the setup-uri command. Pre-cache
+# the encryption npm dep so runtime never needs network access.
+RUN curl -fsSL "https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip" -o /tmp/deno.zip \
+    && unzip /tmp/deno.zip -d /usr/local/bin \
+    && chmod +x /usr/local/bin/deno \
+    && rm /tmp/deno.zip \
+    && deno --version
+
+# Vendor the upstream LiveSync setup URI generator at build time, and
+# pre-cache its npm/jsr deps so runtime never needs network.
+RUN mkdir -p /opt/obsync \
+    && curl -fsSL "https://raw.githubusercontent.com/vrtmrz/obsidian-livesync/${OBSIDIAN_LIVESYNC_REF}/utils/flyio/generate_setupuri.ts" \
+        -o /opt/obsync/generate_setupuri.ts \
+    && deno cache --allow-import /opt/obsync/generate_setupuri.ts
+
+# Bake LiveSync-tuned CouchDB config into the image.
+COPY local.ini /opt/couchdb/etc/local.ini
+
+# Image scripts.
+COPY entrypoint.sh           /usr/local/bin/obsync-entrypoint.sh
+COPY scripts/provision.sh    /opt/obsync/provision.sh
+COPY scripts/obsync          /usr/local/bin/obsync
+RUN chmod +x \
+    /usr/local/bin/obsync-entrypoint.sh \
+    /opt/obsync/provision.sh \
+    /usr/local/bin/obsync
+
+# Run as the existing couchdb user (uid 5984) so the image's chown-on-start
+# block is skipped and read-only mounts work.
+USER 5984:5984
+
+# tini is already present in the upstream image and on PATH.
+ENTRYPOINT ["tini", "--", "/usr/local/bin/obsync-entrypoint.sh"]
+CMD ["/opt/couchdb/bin/couchdb"]

--- a/apps/obsync/docker-bake.hcl
+++ b/apps/obsync/docker-bake.hcl
@@ -1,0 +1,51 @@
+target "docker-metadata-action" {}
+
+variable "VERSION" {
+  // renovate: datasource=docker depName=couchdb versioning=docker
+  default = "3.5.1"
+}
+
+variable "DENO_VERSION" {
+  // renovate: datasource=github-releases depName=denoland/deno extractVersion=^v(?<version>.*)$
+  default = "2.1.4"
+}
+
+variable "OBSIDIAN_LIVESYNC_REF" {
+  # Pin to a specific commit/tag once we want reproducibility.
+  # Tracking 'main' for now — the upstream generate_setupuri.ts changes
+  # rarely and is small enough to manually audit on bumps.
+  // renovate: datasource=github-tags depName=vrtmrz/obsidian-livesync
+  default = "main"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/astrateam-net/containers"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION               = "${VERSION}"
+    DENO_VERSION          = "${DENO_VERSION}"
+    OBSIDIAN_LIVESYNC_REF = "${OBSIDIAN_LIVESYNC_REF}"
+  }
+  labels = {
+    "org.opencontainers.image.source"      = "${SOURCE}"
+    "org.opencontainers.image.title"       = "obsync — CouchDB for Obsidian LiveSync"
+    "org.opencontainers.image.description" = "CouchDB ${VERSION} with declarative provisioning + setup URI CLI for Obsidian Self-hosted LiveSync"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output   = ["type=docker"]
+}
+
+target "image-all" {
+  inherits  = ["image"]
+  platforms = ["linux/amd64", "linux/arm64"]
+}

--- a/apps/obsync/docker-bake.hcl
+++ b/apps/obsync/docker-bake.hcl
@@ -10,14 +10,6 @@ variable "DENO_VERSION" {
   default = "2.1.4"
 }
 
-variable "OBSIDIAN_LIVESYNC_REF" {
-  # Pin to a specific commit/tag once we want reproducibility.
-  # Tracking 'main' for now — the upstream generate_setupuri.ts changes
-  # rarely and is small enough to manually audit on bumps.
-  // renovate: datasource=github-tags depName=vrtmrz/obsidian-livesync
-  default = "main"
-}
-
 variable "SOURCE" {
   default = "https://github.com/astrateam-net/containers"
 }
@@ -29,9 +21,8 @@ group "default" {
 target "image" {
   inherits = ["docker-metadata-action"]
   args = {
-    VERSION               = "${VERSION}"
-    DENO_VERSION          = "${DENO_VERSION}"
-    OBSIDIAN_LIVESYNC_REF = "${OBSIDIAN_LIVESYNC_REF}"
+    VERSION      = "${VERSION}"
+    DENO_VERSION = "${DENO_VERSION}"
   }
   labels = {
     "org.opencontainers.image.source"      = "${SOURCE}"

--- a/apps/obsync/entrypoint.sh
+++ b/apps/obsync/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# obsync image entrypoint: bridges Docker swarm secrets to env vars consumed
+# by the upstream couchdb entrypoint, optionally backgrounds the provisioner,
+# then hands off to the upstream entrypoint with the original CMD.
+set -eu
+
+if [ -f /run/secrets/obsync_admin_user ]; then
+    export COUCHDB_USER=$(cat /run/secrets/obsync_admin_user)
+fi
+if [ -f /run/secrets/obsync_admin_password ]; then
+    export COUCHDB_PASSWORD=$(cat /run/secrets/obsync_admin_password)
+fi
+if [ -f /run/secrets/obsync_chttpd_secret ]; then
+    export COUCHDB_SECRET=$(cat /run/secrets/obsync_chttpd_secret)
+fi
+
+# If a provisioning config is mounted, fork the provisioner so it can run
+# in parallel with CouchDB startup. It polls /_up before doing any work.
+if [ -f /run/secrets/obsync_provisioning_config ]; then
+    /opt/obsync/provision.sh &
+fi
+
+# Hand off to the upstream couchdb entrypoint with the original CMD.
+exec /usr/local/bin/docker-entrypoint.sh "$@"

--- a/apps/obsync/local.ini
+++ b/apps/obsync/local.ini
@@ -29,6 +29,18 @@ require_valid_user_except_for_up = true
 max_http_request_size = 4294967296
 bind_address = 0.0.0.0
 port = 5984
+; Hybrid auth: JWT for LiveSync clients, cookie + basic for admin / curl / Fauxton.
+authentication_handlers = {chttpd_auth, jwt_authentication_handler}, {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
+
+[jwt_auth]
+; LiveSync hardcodes _couchdb.roles=["_admin"] in every JWT it sends. Without
+; overriding roles_claim_name, every authenticated user would silently gain
+; admin privileges across all DBs — defeating per-user / shared-vault isolation.
+; Setting it to a custom name CouchDB will never find means the JWT's claimed
+; roles are ignored, and the server falls back to the user's actual roles
+; from their /_users doc (i.e. none — just per-DB _security membership).
+roles_claim_name = _astra.roles
+required_claims = exp
 
 [httpd]
 WWW-Authenticate = Basic realm="couchdb"

--- a/apps/obsync/local.ini
+++ b/apps/obsync/local.ini
@@ -1,0 +1,49 @@
+; CouchDB config tuned for Obsidian Self-hosted LiveSync.
+; Baked into the image at /opt/couchdb/etc/local.ini.
+; Admin user, [chttpd_auth] secret, and [admins] section are written to
+; /opt/couchdb/etc/local.d/docker.ini by the official entrypoint from
+; COUCHDB_USER / COUCHDB_PASSWORD / COUCHDB_SECRET env vars.
+
+[couchdb]
+single_node = true
+; max_document_size caps ONE document, not file size. LiveSync chunks every file
+; into ~50 KB docs, so this only bites if chunks somehow grow huge. 256 MiB is
+; well above any chunked workload and safely below Erlang VM memory limits.
+; Actual file-size cap is plugin-side syncMaxSizeInMB (set per device).
+max_document_size = 268435456
+max_dbs_open = 500
+
+[cluster]
+; Single-node deployment: default n=3 makes system DB creation fail.
+n = 1
+q = 2
+
+[couch_peruser]
+enable = true
+delete_dbs = false
+
+[chttpd]
+; All requests require valid user EXCEPT /_up (so the container healthcheck
+; works without baking creds into the compose file). Per CouchDB config/auth.rst.
+require_valid_user_except_for_up = true
+max_http_request_size = 4294967296
+bind_address = 0.0.0.0
+port = 5984
+
+[httpd]
+WWW-Authenticate = Basic realm="couchdb"
+enable_cors = true
+
+[chttpd_cors]
+credentials = true
+origins = app://obsidian.md,capacitor://localhost,http://localhost
+
+[cors]
+credentials = true
+origins = app://obsidian.md,capacitor://localhost,http://localhost
+methods = GET, PUT, POST, HEAD, DELETE
+headers = accept, authorization, content-type, origin, referer
+
+[log]
+writer = stderr
+level = info

--- a/apps/obsync/scripts/generate_setupuri.ts
+++ b/apps/obsync/scripts/generate_setupuri.ts
@@ -1,0 +1,131 @@
+// Generate an obsidian://setuplivesync URI for an Obsidian Self-hosted
+// LiveSync vault. Adapted from the upstream generator at
+// https://raw.githubusercontent.com/vrtmrz/obsidian-livesync/main/utils/flyio/generate_setupuri.ts
+// with HTTP-Basic + JWT (ES256/ES512) support driven by env vars.
+//
+// Required env vars (both modes):
+//   hostname   - public CouchDB URL, e.g. https://obsync.example.com
+//   database   - target DB (userdb-<hex> for private, vault name for shared)
+//   passphrase - E2EE passphrase used to encrypt vault content in CouchDB
+//
+// Auth mode selector:
+//   auth_mode  - "basic" (default) or "jwt"
+//
+// Basic mode:
+//   username, password
+//
+// JWT mode (LiveSync experimental, per docs/tips/jwt-on-couchdb.md):
+//   jwt_algorithm     - ES256 | ES512 (default ES256)
+//   jwt_key           - private key in PEM (PKCS#8) format
+//   jwt_kid           - key id matching CouchDB's [jwt_keys] entry
+//   jwt_sub           - subject == CouchDB username
+//   jwt_exp_duration  - token lifetime in minutes (default 60)
+//
+// Optional:
+//   uri_passphrase    - passphrase encrypting the URI itself; auto-generated
+//                       as adjective-noun if unset
+
+import { encrypt } from "npm:octagonal-wheels@0.1.30/encryption/encryption";
+
+const NOUNS = [
+    "waterfall", "river", "breeze", "moon", "rain", "wind", "sea", "morning",
+    "snow", "lake", "sunset", "pine", "shadow", "leaf", "dawn", "glitter",
+    "forest", "hill", "cloud", "meadow", "sun", "glade", "bird", "brook",
+    "butterfly", "bush", "dew", "dust", "field", "fire", "flower", "firefly",
+    "feather", "grass", "haze", "mountain", "night", "pond", "darkness",
+    "snowflake", "silence", "sound", "sky", "shape", "surf", "thunder",
+    "violet", "water", "wildflower", "wave", "resonance", "log", "dream",
+    "cherry", "tree", "fog", "frost", "voice", "paper", "frog", "smoke", "star",
+];
+const ADJECTIVES = [
+    "autumn", "hidden", "bitter", "misty", "silent", "empty", "dry", "dark",
+    "summer", "icy", "delicate", "quiet", "white", "cool", "spring", "winter",
+    "patient", "twilight", "dawn", "crimson", "wispy", "weathered", "blue",
+    "billowing", "broken", "cold", "damp", "falling", "frosty", "green", "long",
+    "late", "lingering", "bold", "little", "morning", "muddy", "old", "red",
+    "rough", "still", "small", "sparkling", "thrumming", "shy", "wandering",
+    "withered", "wild", "black", "young", "holy", "solitary", "fragrant", "aged",
+    "snowy", "proud", "floral", "restless", "divine", "polished", "ancient",
+    "purple", "lively", "nameless",
+];
+
+function friendlyString(): string {
+    const a = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
+    const n = NOUNS[Math.floor(Math.random() * NOUNS.length)];
+    return `${a}-${n}`;
+}
+
+function require(name: string): string {
+    const v = Deno.env.get(name);
+    if (!v) {
+        console.error(`ERROR: env var '${name}' is required`);
+        Deno.exit(2);
+    }
+    return v;
+}
+
+const URIBASE = "obsidian://setuplivesync?settings=";
+
+const uriPassphrase = Deno.env.get("uri_passphrase") || friendlyString();
+const authMode = (Deno.env.get("auth_mode") || "basic").toLowerCase();
+
+// Settings shape mirrors LiveSync's RemoteDBSettings. Field names below
+// were verified against src/modules/features/SettingDialogue/PaneRemoteConfig.ts
+// at the time of writing.
+const base: Record<string, unknown> = {
+    couchDB_URI: require("hostname"),
+    couchDB_DBNAME: require("database"),
+    syncOnStart: true,
+    gcDelay: 0,
+    periodicReplication: true,
+    syncOnFileOpen: true,
+    encrypt: true,
+    passphrase: require("passphrase"),
+    usePathObfuscation: true,
+    batchSave: true,
+    batch_size: 50,
+    batches_limit: 50,
+    useHistory: true,
+    disableRequestURI: true,
+    customChunkSize: 50,
+    syncAfterMerge: false,
+    concurrencyOfReadChunksOnline: 100,
+    minimumIntervalOfReadChunksOnline: 100,
+    handleFilenameCaseSensitive: false,
+    doNotUseFixedRevisionForChunks: false,
+    settingVersion: 10,
+    notifyThresholdOfRemoteStorageSize: 800,
+};
+
+let conf: Record<string, unknown>;
+if (authMode === "jwt") {
+    conf = {
+        ...base,
+        couchDB_USER: "",
+        couchDB_PASSWORD: "",
+        useJWT: true,
+        jwtAlgorithm: Deno.env.get("jwt_algorithm") || "ES256",
+        jwtKey: require("jwt_key"),
+        jwtKid: require("jwt_kid"),
+        jwtSub: require("jwt_sub"),
+        jwtExpDuration: parseInt(Deno.env.get("jwt_exp_duration") || "60", 10),
+    };
+} else if (authMode === "basic") {
+    conf = {
+        ...base,
+        couchDB_USER: require("username"),
+        couchDB_PASSWORD: require("password"),
+        useJWT: false,
+    };
+} else {
+    console.error(`ERROR: unknown auth_mode '${authMode}' (expected 'basic' or 'jwt')`);
+    Deno.exit(2);
+}
+
+const encrypted = encodeURIComponent(
+    await encrypt(JSON.stringify(conf), uriPassphrase, false),
+);
+console.log();
+console.log(`Your passphrase of Setup-URI is:  ${uriPassphrase}`);
+console.log("This passphrase is never shown again, so please note it in a safe place.");
+console.log(`${URIBASE}${encrypted}`);

--- a/apps/obsync/scripts/obsync
+++ b/apps/obsync/scripts/obsync
@@ -38,9 +38,10 @@ cmd_setup_uri() {
     local user=${1:-}; local vault=${2:-}
     [ -z "$user" ] && die "usage: obsync setup-uri <user> [shared-vault]"
 
-    local pw passphrase db
-    pw=$(jq -r --arg u "$user" '.users[$u].password // empty' "$CONFIG")
-    [ -z "$pw" ] && die "user '$user' not found in provisioning config"
+    local passphrase db
+    if ! jq -e --arg u "$user" '.users[$u]' "$CONFIG" >/dev/null; then
+        die "user '$user' not found in provisioning config"
+    fi
 
     if [ -z "$vault" ]; then
         db=$(userdb_name "$user")
@@ -59,10 +60,36 @@ cmd_setup_uri() {
         echo "=== shared vault: $user → $db ==="
     fi
 
+    # Prefer JWT mode if the user has a jwt block in the provisioning config;
+    # fall back to HTTP Basic otherwise. JWT setup URIs carry the user's
+    # private key + kid + sub; Basic carries the user's password.
+    local has_jwt
+    has_jwt=$(jq -r --arg u "$user" '.users[$u].jwt // empty | (.private_key // "") | length > 0' "$CONFIG")
+
     echo
-    hostname="$PUBLIC_URL" username="$user" password="$pw" \
-        database="$db" passphrase="$passphrase" \
-        deno run -A --quiet /opt/obsync/generate_setupuri.ts
+    if [ "$has_jwt" = "true" ]; then
+        local alg priv kid exp
+        alg=$(jq -r  --arg u "$user" '.users[$u].jwt.algorithm     // "ES256"' "$CONFIG")
+        priv=$(jq -r --arg u "$user" '.users[$u].jwt.private_key'             "$CONFIG")
+        kid=$(jq -r  --arg u "$user" '.users[$u].jwt.kid             // $u'   "$CONFIG")
+        exp=$(jq -r  --arg u "$user" '.users[$u].jwt.exp_duration_minutes // 60' "$CONFIG")
+        echo "(JWT mode — alg=$alg, kid=$kid, exp=${exp} min)"
+        echo
+        hostname="$PUBLIC_URL" database="$db" passphrase="$passphrase" \
+            auth_mode="jwt" \
+            jwt_algorithm="$alg" jwt_key="$priv" jwt_kid="$kid" \
+            jwt_sub="$user" jwt_exp_duration="$exp" \
+            deno run -A --quiet /opt/obsync/generate_setupuri.ts
+    else
+        local pw
+        pw=$(jq -r --arg u "$user" '.users[$u].password // empty' "$CONFIG")
+        [ -z "$pw" ] && die "user '$user' has neither jwt block nor password set"
+        echo "(HTTP Basic mode)"
+        echo
+        hostname="$PUBLIC_URL" database="$db" passphrase="$passphrase" \
+            auth_mode="basic" username="$user" password="$pw" \
+            deno run -A --quiet /opt/obsync/generate_setupuri.ts
+    fi
     echo
     echo "Hand the URI and the uri_passphrase to the user over DIFFERENT"
     echo "channels (URI via clipboard/email, passphrase typed/spoken)."

--- a/apps/obsync/scripts/obsync
+++ b/apps/obsync/scripts/obsync
@@ -1,0 +1,166 @@
+#!/bin/bash
+# obsync — operator CLI for the obsync image.
+# Usage: obsync <subcommand> [args]
+#
+# Designed to run via `docker exec obsync_app obsync <...>`. Reads admin
+# credentials from /run/secrets and the provisioning config (users, vaults,
+# passphrases) from the same source the boot provisioner uses.
+
+set -eu
+
+URL=http://localhost:5984
+CONFIG=/run/secrets/obsync_provisioning_config
+
+# Public hostname embedded in setup URIs. Set in compose:
+#   environment:
+#     - OBSYNC_PUBLIC_URL=https://obsync.example.com
+PUBLIC_URL=${OBSYNC_PUBLIC_URL:-https://localhost:5984}
+
+die()  { echo "ERROR: $*" >&2; exit 1; }
+need() { [ -f "$CONFIG" ] || die "provisioning config not mounted at $CONFIG"; }
+
+# Lazy admin-cred load — only read when a subcommand needs them. Lets `help`
+# and similar work in environments without secrets mounted (e.g. CI tests).
+load_admin_creds() {
+    [ -f /run/secrets/obsync_admin_user ] || die "admin user secret not mounted"
+    [ -f /run/secrets/obsync_admin_password ] || die "admin password secret not mounted"
+    ADMIN_USER=$(cat /run/secrets/obsync_admin_user)
+    ADMIN_PASS=$(cat /run/secrets/obsync_admin_password)
+}
+
+userdb_name() {
+    # CouchDB couch_peruser convention: userdb-<hex(utf8(name))>
+    printf 'userdb-%s' "$(printf '%s' "$1" | xxd -p | tr -d '\n')"
+}
+
+cmd_setup_uri() {
+    need
+    local user=${1:-}; local vault=${2:-}
+    [ -z "$user" ] && die "usage: obsync setup-uri <user> [shared-vault]"
+
+    local pw passphrase db
+    pw=$(jq -r --arg u "$user" '.users[$u].password // empty' "$CONFIG")
+    [ -z "$pw" ] && die "user '$user' not found in provisioning config"
+
+    if [ -z "$vault" ]; then
+        db=$(userdb_name "$user")
+        passphrase=$(jq -r --arg u "$user" '.users[$u].e2ee_passphrase // empty' "$CONFIG")
+        [ -z "$passphrase" ] && die "user '$user' has no e2ee_passphrase set"
+        echo "=== private vault: $user → $db ==="
+    else
+        db=$vault
+        passphrase=$(jq -r --arg v "$vault" '.shared_vaults[$v].e2ee_passphrase // empty' "$CONFIG")
+        [ -z "$passphrase" ] && die "shared vault '$vault' not in provisioning config"
+        if ! jq -e --arg u "$user" --arg v "$vault" \
+                '.shared_vaults[$v].members | index($u) != null' "$CONFIG" >/dev/null
+        then
+            die "user '$user' is not a member of '$vault' (per provisioning config)"
+        fi
+        echo "=== shared vault: $user → $db ==="
+    fi
+
+    echo
+    hostname="$PUBLIC_URL" username="$user" password="$pw" \
+        database="$db" passphrase="$passphrase" \
+        deno run -A --quiet /opt/obsync/generate_setupuri.ts
+    echo
+    echo "Hand the URI and the uri_passphrase to the user over DIFFERENT"
+    echo "channels (URI via clipboard/email, passphrase typed/spoken)."
+}
+
+cmd_user_list() {
+    need
+    local users
+    users=$(jq -r '(.users // {}) | keys[]' "$CONFIG")
+    [ -z "$users" ] && { echo "(no users in provisioning config)"; return; }
+    while IFS= read -r u; do
+        local in_vaults
+        in_vaults=$(jq -r --arg u "$u" \
+            '[(.shared_vaults // {}) | to_entries[]
+              | select(.value.members | index($u)) | .key] | join(", ")' \
+            "$CONFIG")
+        if [ -n "$in_vaults" ]; then
+            printf '%-20s  private + %s\n' "$u" "$in_vaults"
+        else
+            printf '%-20s  private only\n' "$u"
+        fi
+    done <<< "$users"
+}
+
+cmd_vault_list() {
+    need
+    jq -r '(.shared_vaults // {}) | to_entries[]
+           | "\(.key)\t\(.value.members | join(", "))"' "$CONFIG" \
+    | while IFS=$'\t' read -r v m; do
+        printf '%-30s  members: %s\n' "$v" "${m:-<none>}"
+    done
+}
+
+cmd_user_purge() {
+    local user=${1:-}
+    [ -z "$user" ] && die "usage: obsync user-purge <user>"
+    load_admin_creds
+
+    printf 'DELETE user %s AND their userdb? [type "yes" to confirm]: ' "$user"
+    read -r confirm
+    [ "$confirm" = yes ] || die "aborted"
+
+    local rev
+    rev=$(curl -sS -u "$ADMIN_USER:$ADMIN_PASS" \
+        "$URL/_users/org.couchdb.user:$user" | jq -r '._rev // empty')
+    if [ -n "$rev" ]; then
+        curl -sf -u "$ADMIN_USER:$ADMIN_PASS" -X DELETE \
+            "$URL/_users/org.couchdb.user:$user?rev=$rev" >/dev/null
+        echo "deleted user $user"
+    else
+        echo "user $user not found in /_users (skipping)"
+    fi
+
+    local db; db=$(userdb_name "$user")
+    if curl -sf -u "$ADMIN_USER:$ADMIN_PASS" "$URL/$db" >/dev/null 2>&1; then
+        curl -sf -u "$ADMIN_USER:$ADMIN_PASS" -X DELETE "$URL/$db" >/dev/null
+        echo "deleted database $db"
+    else
+        echo "database $db not found (skipping)"
+    fi
+
+    echo "NOTE: any shared-vault membership remains in those vaults' _security"
+    echo "      docs. Remove the user from topology.yaml + redeploy to clean up."
+}
+
+cmd_provision_now() {
+    /opt/obsync/provision.sh
+}
+
+cmd_help() {
+    cat <<'EOF'
+obsync — Obsidian LiveSync CouchDB ops CLI
+
+Usage: obsync <subcommand> [args]
+
+  setup-uri <user>                  Generate setup URI for user's private vault
+  setup-uri <user> <shared-vault>   Generate setup URI for a shared vault
+  user-list                         List managed users + their vault memberships
+  vault-list                        List shared vaults + members
+  user-purge <user>                 Delete user account + private DB (interactive)
+  provision-now                     Re-run the boot provisioner immediately
+  help                              This message
+
+The CLI reads admin creds from /run/secrets/obsync_admin_*  and the
+provisioning config (users, vaults, passphrases) from
+/run/secrets/obsync_provisioning_config. Set OBSYNC_PUBLIC_URL in compose
+to the public hostname embedded in setup URIs.
+EOF
+}
+
+cmd=${1:-help}
+shift || true
+case "$cmd" in
+    setup-uri)     cmd_setup_uri "$@" ;;
+    user-list)     cmd_user_list ;;
+    vault-list)    cmd_vault_list ;;
+    user-purge)    cmd_user_purge "$@" ;;
+    provision-now) cmd_provision_now ;;
+    help|-h|--help) cmd_help ;;
+    *) echo "unknown subcommand: $cmd" >&2; cmd_help; exit 2 ;;
+esac

--- a/apps/obsync/scripts/provision.sh
+++ b/apps/obsync/scripts/provision.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Boot-time provisioner. Reads a JSON provisioning config from a Docker swarm
+# secret and ensures CouchDB users, shared databases, and _security membership
+# match. Idempotent — safe to run on every container start.
+#
+# The config secret JSON shape:
+#   {
+#     "users": {
+#       "alice": { "password": "...", "e2ee_passphrase": "..." },
+#       ...
+#     },
+#     "shared_vaults": {
+#       "team-engineering": { "members": ["alice","bob"], "e2ee_passphrase": "..." },
+#       ...
+#     }
+#   }
+#
+# E2EE passphrases are not used by CouchDB itself — they're handed to the
+# `obsync setup-uri` command later. They live in the same config so the
+# image has a single source of truth.
+
+set -eu
+
+LOG_PREFIX="[provision]"
+log() { echo "${LOG_PREFIX} $*"; }
+
+ADMIN_USER=$(cat /run/secrets/obsync_admin_user)
+ADMIN_PASS=$(cat /run/secrets/obsync_admin_password)
+URL=http://localhost:5984
+CONFIG=/run/secrets/obsync_provisioning_config
+
+if [ ! -f "$CONFIG" ]; then
+    log "no provisioning config mounted at $CONFIG; skipping"
+    exit 0
+fi
+
+# Wait up to 90s for CouchDB to be reachable. /_up is exempt from auth.
+log "waiting for CouchDB to be ready..."
+for _ in $(seq 1 90); do
+    if curl -fsS "$URL/_up" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+if ! curl -fsS "$URL/_up" >/dev/null 2>&1; then
+    log "FATAL: CouchDB did not respond to /_up within 90s; aborting"
+    exit 1
+fi
+log "CouchDB ready"
+
+# 1. Ensure system databases exist (idempotent).
+for db in _users _replicator _global_changes; do
+    code=$(curl -s -o /dev/null -w '%{http_code}' \
+        -u "$ADMIN_USER:$ADMIN_PASS" "$URL/$db")
+    if [ "$code" = "404" ]; then
+        log "creating system db $db"
+        curl -sf -u "$ADMIN_USER:$ADMIN_PASS" -X PUT "$URL/$db" >/dev/null \
+            || log "WARN: PUT /$db failed"
+    fi
+done
+
+# 2. Ensure each managed user exists / has the right password.
+#    The presence of `_rev` distinguishes update from create. CouchDB hashes
+#    the plaintext on first auth and rewrites the doc — that's fine, our PUT
+#    just provides the canonical password each time.
+jq -r '(.users // {}) | to_entries[] | "\(.key)\t\(.value.password)"' "$CONFIG" \
+| while IFS=$'\t' read -r name password; do
+    [ -z "$name" ] && continue
+    log "ensuring user '$name'"
+    existing=$(curl -sS -u "$ADMIN_USER:$ADMIN_PASS" \
+        "$URL/_users/org.couchdb.user:$name")
+    rev=$(printf '%s' "$existing" | jq -r '._rev // empty')
+
+    if [ -n "$rev" ]; then
+        body=$(jq -nc --arg n "$name" --arg p "$password" --arg r "$rev" \
+            '{_id:("org.couchdb.user:"+$n), _rev:$r, name:$n, password:$p, roles:[], type:"user"}')
+    else
+        body=$(jq -nc --arg n "$name" --arg p "$password" \
+            '{name:$n, password:$p, roles:[], type:"user"}')
+    fi
+
+    code=$(printf '%s' "$body" | curl -s -o /dev/null -w '%{http_code}' \
+        -u "$ADMIN_USER:$ADMIN_PASS" -X PUT \
+        -H 'content-type: application/json' \
+        --data-binary @- "$URL/_users/org.couchdb.user:$name")
+    case "$code" in
+        201|200) ;;
+        409)     log "WARN: rev conflict for $name (will retry next boot)" ;;
+        *)       log "WARN: PUT user $name returned $code" ;;
+    esac
+done
+
+# 3. Ensure each shared vault exists with declared membership.
+jq -r '(.shared_vaults // {}) | to_entries[]
+       | "\(.key)\t\(.value.members | join(","))"' "$CONFIG" \
+| while IFS=$'\t' read -r vault members; do
+    [ -z "$vault" ] && continue
+    log "ensuring shared vault '$vault' with members: ${members:-<none>}"
+
+    code=$(curl -s -o /dev/null -w '%{http_code}' \
+        -u "$ADMIN_USER:$ADMIN_PASS" "$URL/$vault")
+    if [ "$code" = "404" ]; then
+        log "creating db $vault"
+        curl -sf -u "$ADMIN_USER:$ADMIN_PASS" -X PUT "$URL/$vault" >/dev/null \
+            || { log "WARN: PUT /$vault failed"; continue; }
+    fi
+
+    members_json=$(printf '%s' "$members" | jq -Rc 'if . == "" then [] else split(",") end')
+    sec=$(jq -nc --argjson m "$members_json" \
+        '{admins:{names:[],roles:[]}, members:{names:$m,roles:[]}}')
+    printf '%s' "$sec" | curl -sf -u "$ADMIN_USER:$ADMIN_PASS" -X PUT \
+        -H 'content-type: application/json' \
+        --data-binary @- "$URL/$vault/_security" >/dev/null \
+        || log "WARN: PUT /$vault/_security failed"
+done
+
+log "provisioning complete"

--- a/apps/obsync/scripts/provision.sh
+++ b/apps/obsync/scripts/provision.sh
@@ -1,23 +1,33 @@
 #!/bin/bash
 # Boot-time provisioner. Reads a JSON provisioning config from a Docker swarm
-# secret and ensures CouchDB users, shared databases, and _security membership
-# match. Idempotent — safe to run on every container start.
+# secret and ensures CouchDB users, JWT public keys, shared databases, and
+# _security membership match. Idempotent — safe to run on every boot.
 #
 # The config secret JSON shape:
 #   {
 #     "users": {
-#       "alice": { "password": "...", "e2ee_passphrase": "..." },
+#       "alice": {
+#         "password": "...",
+#         "e2ee_passphrase": "...",
+#         "jwt": {                              # optional; if present, public
+#           "public_key": "-----BEGIN PUBLIC KEY-----\n...\n",
+#           "algorithm":  "ES256"               # or ES512
+#         }
+#       },
 #       ...
 #     },
 #     "shared_vaults": {
-#       "team-engineering": { "members": ["alice","bob"], "e2ee_passphrase": "..." },
+#       "team-engineering": {
+#         "members":         ["alice","bob"],
+#         "e2ee_passphrase": "..."
+#       },
 #       ...
 #     }
 #   }
 #
-# E2EE passphrases are not used by CouchDB itself — they're handed to the
-# `obsync setup-uri` command later. They live in the same config so the
-# image has a single source of truth.
+# The `e2ee_passphrase` and `jwt.private_key` (if any) are not consumed here —
+# they're handed to the `obsync setup-uri` command later. They live in the
+# same config so the image has a single source of truth.
 
 set -eu
 
@@ -34,7 +44,6 @@ if [ ! -f "$CONFIG" ]; then
     exit 0
 fi
 
-# Wait up to 90s for CouchDB to be reachable. /_up is exempt from auth.
 log "waiting for CouchDB to be ready..."
 for _ in $(seq 1 90); do
     if curl -fsS "$URL/_up" >/dev/null 2>&1; then
@@ -59,10 +68,7 @@ for db in _users _replicator _global_changes; do
     fi
 done
 
-# 2. Ensure each managed user exists / has the right password.
-#    The presence of `_rev` distinguishes update from create. CouchDB hashes
-#    the plaintext on first auth and rewrites the doc — that's fine, our PUT
-#    just provides the canonical password each time.
+# 2. Ensure each managed user exists with the declared password.
 jq -r '(.users // {}) | to_entries[] | "\(.key)\t\(.value.password)"' "$CONFIG" \
 | while IFS=$'\t' read -r name password; do
     [ -z "$name" ] && continue
@@ -90,7 +96,45 @@ jq -r '(.users // {}) | to_entries[] | "\(.key)\t\(.value.password)"' "$CONFIG" 
     esac
 done
 
-# 3. Ensure each shared vault exists with declared membership.
+# 3. Install / refresh per-user JWT public keys via REST.
+#    [jwt_keys] ec:<kid> = <public-key-PEM>
+#    The kid we use is the username — keeps things simple, one key per user.
+#    The PEM string is sent as a JSON-encoded string so newlines in the key
+#    survive the round trip.
+jq -c '(.users // {}) | to_entries[]
+       | select(.value.jwt? != null)
+       | {name: .key, alg: .value.jwt.algorithm, key: .value.jwt.public_key}' "$CONFIG" \
+| while IFS= read -r row; do
+    [ -z "$row" ] && continue
+    name=$(printf '%s' "$row" | jq -r '.name')
+    pem=$(printf '%s' "$row"  | jq -r '.key')
+    alg=$(printf '%s' "$row"  | jq -r '.alg // "ES256"')
+
+    # CouchDB jwt_keys section uses the algorithm family as the key prefix.
+    # ES256 / ES512 → ec:<kid>; HS256/HS512 (we don't use) would be hmac:<kid>.
+    case "$alg" in
+        ES256|ES512) family=ec ;;
+        *) log "WARN: user $name has unsupported jwt algorithm '$alg'; skipping"; continue ;;
+    esac
+
+    log "installing JWT public key for '$name' (alg=$alg, kid=$name)"
+    # CouchDB stores config values as raw strings — multi-line PEMs are
+    # rejected as "Invalid configuration value". The convention (also used
+    # by Fauxton) is to escape literal newlines as the 2-char sequence \n
+    # in the stored value; CouchDB's PEM parser then re-interprets those
+    # at validation time. See: docs/tips/jwt-on-couchdb.md upstream.
+    json_body=$(jq -nc --arg p "$pem" '$p | gsub("\n"; "\\n")')
+    code=$(printf '%s' "$json_body" | curl -s -o /dev/null -w '%{http_code}' \
+        -u "$ADMIN_USER:$ADMIN_PASS" -X PUT \
+        -H 'content-type: application/json' \
+        --data-binary @- "$URL/_node/_local/_config/jwt_keys/${family}:${name}")
+    case "$code" in
+        200) ;;
+        *)   log "WARN: PUT jwt_keys/${family}:${name} returned $code" ;;
+    esac
+done
+
+# 4. Ensure each shared vault exists with declared membership.
 jq -r '(.shared_vaults // {}) | to_entries[]
        | "\(.key)\t\(.value.members | join(","))"' "$CONFIG" \
 | while IFS=$'\t' read -r vault members; do

--- a/apps/obsync/tests.yaml
+++ b/apps/obsync/tests.yaml
@@ -1,0 +1,66 @@
+---
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "couchdb binary present"
+    command: "/opt/couchdb/bin/couchdb"
+    args: ["-version"]
+    exitCode: 0
+
+  - name: "deno installed"
+    command: "deno"
+    args: ["--version"]
+    exitCode: 0
+
+  - name: "jq installed"
+    command: "jq"
+    args: ["--version"]
+    exitCode: 0
+
+  - name: "curl installed"
+    command: "curl"
+    args: ["--version"]
+    exitCode: 0
+
+  - name: "xxd installed (used to compute userdb-<hex> name)"
+    command: "xxd"
+    args: ["-v"]
+    exitCode: 0
+
+  - name: "obsync CLI prints help"
+    command: "/usr/local/bin/obsync"
+    args: ["help"]
+    exitCode: 0
+
+fileExistenceTests:
+  - name: "baked local.ini"
+    path: /opt/couchdb/etc/local.ini
+    shouldExist: true
+
+  - name: "entrypoint script"
+    path: /usr/local/bin/obsync-entrypoint.sh
+    shouldExist: true
+    permissions: "-rwxr-xr-x"
+
+  - name: "provisioner"
+    path: /opt/obsync/provision.sh
+    shouldExist: true
+    permissions: "-rwxr-xr-x"
+
+  - name: "obsync CLI on PATH"
+    path: /usr/local/bin/obsync
+    shouldExist: true
+    permissions: "-rwxr-xr-x"
+
+  - name: "vendored generate_setupuri.ts"
+    path: /opt/obsync/generate_setupuri.ts
+    shouldExist: true
+
+fileContentTests:
+  - name: "local.ini has couch_peruser enabled"
+    path: /opt/couchdb/etc/local.ini
+    expectedContents: ['enable = true']
+
+  - name: "local.ini has require_valid_user_except_for_up"
+    path: /opt/couchdb/etc/local.ini
+    expectedContents: ['require_valid_user_except_for_up = true']


### PR DESCRIPTION
## Summary
- LiveSync clients authenticate via per-user JWT (ES256 / ES512); admin / curl / Fauxton / healthcheck stay on HTTP Basic + cookie
- Critical safety override: `jwt_auth.roles_claim_name = _astra.roles` so LiveSync's hardcoded `_couchdb.roles=["_admin"]` is ignored — without this, every LiveSync client gets full admin
- Provisioner installs each user's public key into `[jwt_keys] ec:<username>` via REST (newline escape required: literal `\n`)
- New custom `generate_setupuri.ts` supports both `auth_mode=basic` and `auth_mode=jwt`; CLI auto-selects JWT when the user has a `jwt.private_key` in the provisioning config

## Test plan
- [x] Build passes; CST 13/13 pass
- [x] End-to-end smoke with EC P-256 keypair:
  - Provisioner creates user, installs public key
  - `obsync setup-uri alice` returns JWT-mode URI (alg ES256, kid alice, exp 60 min)
  - `obsync setup-uri bob` (no jwt block) falls back to Basic mode
  - `obsync setup-uri alice team-shared` returns JWT-mode URI for shared vault
  - CouchDB config verified via REST: `authentication_handlers`, `jwt_auth`, `jwt_keys/ec:alice`

🤖 Generated with [Claude Code](https://claude.com/claude-code)