### PR TITLE
feat(obsync): JWT for clients + Basic for admin (hybrid auth)

### DIFF
--- a/apps/obsync/Dockerfile
+++ b/apps/obsync/Dockerfile
@@ -8,7 +8,6 @@ ARG VERSION
 FROM docker.io/couchdb:${VERSION}
 
 ARG DENO_VERSION
-ARG OBSIDIAN_LIVESYNC_REF
 ARG TARGETARCH
 
 USER root
@@ -33,24 +32,23 @@ RUN case "${TARGETARCH}" in \
     && rm /tmp/deno.zip \
     && deno --version
 
-# Vendor the upstream LiveSync setup URI generator at build time, and
-# pre-cache its npm/jsr deps so runtime never needs network.
-RUN mkdir -p /opt/obsync \
-    && curl -fsSL "https://raw.githubusercontent.com/vrtmrz/obsidian-livesync/${OBSIDIAN_LIVESYNC_REF}/utils/flyio/generate_setupuri.ts" \
-        -o /opt/obsync/generate_setupuri.ts \
-    && deno cache --allow-import /opt/obsync/generate_setupuri.ts
+RUN mkdir -p /opt/obsync
 
 # Bake LiveSync-tuned CouchDB config into the image.
 COPY local.ini /opt/couchdb/etc/local.ini
 
-# Image scripts.
-COPY entrypoint.sh           /usr/local/bin/obsync-entrypoint.sh
-COPY scripts/provision.sh    /opt/obsync/provision.sh
-COPY scripts/obsync          /usr/local/bin/obsync
+# Image scripts. Custom generate_setupuri.ts (extends upstream with JWT mode)
+# is shipped from this repo rather than fetched at build time, so the URI
+# format stays under our control and reproducible.
+COPY entrypoint.sh                  /usr/local/bin/obsync-entrypoint.sh
+COPY scripts/provision.sh           /opt/obsync/provision.sh
+COPY scripts/obsync                 /usr/local/bin/obsync
+COPY scripts/generate_setupuri.ts   /opt/obsync/generate_setupuri.ts
 RUN chmod +x \
-    /usr/local/bin/obsync-entrypoint.sh \
-    /opt/obsync/provision.sh \
-    /usr/local/bin/obsync
+        /usr/local/bin/obsync-entrypoint.sh \
+        /opt/obsync/provision.sh \
+        /usr/local/bin/obsync \
+    && deno cache --allow-import /opt/obsync/generate_setupuri.ts
 
 # Run as the existing couchdb user (uid 5984) so the image's chown-on-start
 # block is skipped and read-only mounts work.

--- a/apps/obsync/docker-bake.hcl
+++ b/apps/obsync/docker-bake.hcl
@@ -10,14 +10,6 @@ variable "DENO_VERSION" {
   default = "2.1.4"
 }
 
-variable "OBSIDIAN_LIVESYNC_REF" {
-  # Pin to a specific commit/tag once we want reproducibility.
-  # Tracking 'main' for now — the upstream generate_setupuri.ts changes
-  # rarely and is small enough to manually audit on bumps.
-  // renovate: datasource=github-tags depName=vrtmrz/obsidian-livesync
-  default = "main"
-}
-
 variable "SOURCE" {
   default = "https://github.com/astrateam-net/containers"
 }
@@ -29,9 +21,8 @@ group "default" {
 target "image" {
   inherits = ["docker-metadata-action"]
   args = {
-    VERSION               = "${VERSION}"
-    DENO_VERSION          = "${DENO_VERSION}"
-    OBSIDIAN_LIVESYNC_REF = "${OBSIDIAN_LIVESYNC_REF}"
+    VERSION      = "${VERSION}"
+    DENO_VERSION = "${DENO_VERSION}"
   }
   labels = {
     "org.opencontainers.image.source"      = "${SOURCE}"

--- a/apps/obsync/local.ini
+++ b/apps/obsync/local.ini
@@ -29,6 +29,18 @@ require_valid_user_except_for_up = true
 max_http_request_size = 4294967296
 bind_address = 0.0.0.0
 port = 5984
+; Hybrid auth: JWT for LiveSync clients, cookie + basic for admin / curl / Fauxton.
+authentication_handlers = {chttpd_auth, jwt_authentication_handler}, {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
+
+[jwt_auth]
+; LiveSync hardcodes _couchdb.roles=["_admin"] in every JWT it sends. Without
+; overriding roles_claim_name, every authenticated user would silently gain
+; admin privileges across all DBs — defeating per-user / shared-vault isolation.
+; Setting it to a custom name CouchDB will never find means the JWT's claimed
+; roles are ignored, and the server falls back to the user's actual roles
+; from their /_users doc (i.e. none — just per-DB _security membership).
+roles_claim_name = _astra.roles
+required_claims = exp
 
 [httpd]
 WWW-Authenticate = Basic realm="couchdb"

--- a/apps/obsync/scripts/generate_setupuri.ts
+++ b/apps/obsync/scripts/generate_setupuri.ts
@@ -1,0 +1,131 @@
+// Generate an obsidian://setuplivesync URI for an Obsidian Self-hosted
+// LiveSync vault. Adapted from the upstream generator at
+// https://raw.githubusercontent.com/vrtmrz/obsidian-livesync/main/utils/flyio/generate_setupuri.ts
+// with HTTP-Basic + JWT (ES256/ES512) support driven by env vars.
+//
+// Required env vars (both modes):
+//   hostname   - public CouchDB URL, e.g. https://obsync.example.com
+//   database   - target DB (userdb-<hex> for private, vault name for shared)
+//   passphrase - E2EE passphrase used to encrypt vault content in CouchDB
+//
+// Auth mode selector:
+//   auth_mode  - "basic" (default) or "jwt"
+//
+// Basic mode:
+//   username, password
+//
+// JWT mode (LiveSync experimental, per docs/tips/jwt-on-couchdb.md):
+//   jwt_algorithm     - ES256 | ES512 (default ES256)
+//   jwt_key           - private key in PEM (PKCS#8) format
+//   jwt_kid           - key id matching CouchDB's [jwt_keys] entry
+//   jwt_sub           - subject == CouchDB username
+//   jwt_exp_duration  - token lifetime in minutes (default 60)
+//
+// Optional:
+//   uri_passphrase    - passphrase encrypting the URI itself; auto-generated
+//                       as adjective-noun if unset
+
+import { encrypt } from "npm:octagonal-wheels@0.1.30/encryption/encryption";
+
+const NOUNS = [
+    "waterfall", "river", "breeze", "moon", "rain", "wind", "sea", "morning",
+    "snow", "lake", "sunset", "pine", "shadow", "leaf", "dawn", "glitter",
+    "forest", "hill", "cloud", "meadow", "sun", "glade", "bird", "brook",
+    "butterfly", "bush", "dew", "dust", "field", "fire", "flower", "firefly",
+    "feather", "grass", "haze", "mountain", "night", "pond", "darkness",
+    "snowflake", "silence", "sound", "sky", "shape", "surf", "thunder",
+    "violet", "water", "wildflower", "wave", "resonance", "log", "dream",
+    "cherry", "tree", "fog", "frost", "voice", "paper", "frog", "smoke", "star",
+];
+const ADJECTIVES = [
+    "autumn", "hidden", "bitter", "misty", "silent", "empty", "dry", "dark",
+    "summer", "icy", "delicate", "quiet", "white", "cool", "spring", "winter",
+    "patient", "twilight", "dawn", "crimson", "wispy", "weathered", "blue",
+    "billowing", "broken", "cold", "damp", "falling", "frosty", "green", "long",
+    "late", "lingering", "bold", "little", "morning", "muddy", "old", "red",
+    "rough", "still", "small", "sparkling", "thrumming", "shy", "wandering",
+    "withered", "wild", "black", "young", "holy", "solitary", "fragrant", "aged",
+    "snowy", "proud", "floral", "restless", "divine", "polished", "ancient",
+    "purple", "lively", "nameless",
+];
+
+function friendlyString(): string {
+    const a = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
+    const n = NOUNS[Math.floor(Math.random() * NOUNS.length)];
+    return `${a}-${n}`;
+}
+
+function require(name: string): string {
+    const v = Deno.env.get(name);
+    if (!v) {
+        console.error(`ERROR: env var '${name}' is required`);
+        Deno.exit(2);
+    }
+    return v;
+}
+
+const URIBASE = "obsidian://setuplivesync?settings=";
+
+const uriPassphrase = Deno.env.get("uri_passphrase") || friendlyString();
+const authMode = (Deno.env.get("auth_mode") || "basic").toLowerCase();
+
+// Settings shape mirrors LiveSync's RemoteDBSettings. Field names below
+// were verified against src/modules/features/SettingDialogue/PaneRemoteConfig.ts
+// at the time of writing.
+const base: Record<string, unknown> = {
+    couchDB_URI: require("hostname"),
+    couchDB_DBNAME: require("database"),
+    syncOnStart: true,
+    gcDelay: 0,
+    periodicReplication: true,
+    syncOnFileOpen: true,
+    encrypt: true,
+    passphrase: require("passphrase"),
+    usePathObfuscation: true,
+    batchSave: true,
+    batch_size: 50,
+    batches_limit: 50,
+    useHistory: true,
+    disableRequestURI: true,
+    customChunkSize: 50,
+    syncAfterMerge: false,
+    concurrencyOfReadChunksOnline: 100,
+    minimumIntervalOfReadChunksOnline: 100,
+    handleFilenameCaseSensitive: false,
+    doNotUseFixedRevisionForChunks: false,
+    settingVersion: 10,
+    notifyThresholdOfRemoteStorageSize: 800,
+};
+
+let conf: Record<string, unknown>;
+if (authMode === "jwt") {
+    conf = {
+        ...base,
+        couchDB_USER: "",
+        couchDB_PASSWORD: "",
+        useJWT: true,
+        jwtAlgorithm: Deno.env.get("jwt_algorithm") || "ES256",
+        jwtKey: require("jwt_key"),
+        jwtKid: require("jwt_kid"),
+        jwtSub: require("jwt_sub"),
+        jwtExpDuration: parseInt(Deno.env.get("jwt_exp_duration") || "60", 10),
+    };
+} else if (authMode === "basic") {
+    conf = {
+        ...base,
+        couchDB_USER: require("username"),
+        couchDB_PASSWORD: require("password"),
+        useJWT: false,
+    };
+} else {
+    console.error(`ERROR: unknown auth_mode '${authMode}' (expected 'basic' or 'jwt')`);
+    Deno.exit(2);
+}
+
+const encrypted = encodeURIComponent(
+    await encrypt(JSON.stringify(conf), uriPassphrase, false),
+);
+console.log();
+console.log(`Your passphrase of Setup-URI is:  ${uriPassphrase}`);
+console.log("This passphrase is never shown again, so please note it in a safe place.");
+console.log(`${URIBASE}${encrypted}`);

--- a/apps/obsync/scripts/obsync
+++ b/apps/obsync/scripts/obsync
@@ -38,10 +38,11 @@ cmd_setup_uri() {
     local user=${1:-}; local vault=${2:-}
     [ -z "$user" ] && die "usage: obsync setup-uri <user> [shared-vault]"
 
-    local pw passphrase db
-    pw=$(jq -r --arg u "$user" '.users[$u].password // empty' "$CONFIG")
-    [ -z "$pw" ] && die "user '$user' not found in provisioning config"
+    if ! jq -e --arg u "$user" '.users[$u]' "$CONFIG" >/dev/null; then
+        die "user '$user' not found in provisioning config"
+    fi
 
+    local passphrase db
     if [ -z "$vault" ]; then
         db=$(userdb_name "$user")
         passphrase=$(jq -r --arg u "$user" '.users[$u].e2ee_passphrase // empty' "$CONFIG")
@@ -59,10 +60,37 @@ cmd_setup_uri() {
         echo "=== shared vault: $user → $db ==="
     fi
 
+    # Prefer JWT mode if the user has a jwt block in the provisioning config;
+    # fall back to HTTP Basic otherwise. JWT setup URIs carry the user's
+    # private key + kid + sub; Basic carries the user's password.
+    local has_jwt
+    has_jwt=$(jq -r --arg u "$user" \
+        '(.users[$u].jwt // empty) | (.private_key // "") | length > 0' "$CONFIG")
+
     echo
-    hostname="$PUBLIC_URL" username="$user" password="$pw" \
-        database="$db" passphrase="$passphrase" \
-        deno run -A --quiet /opt/obsync/generate_setupuri.ts
+    if [ "$has_jwt" = "true" ]; then
+        local alg priv kid exp
+        alg=$(jq -r  --arg u "$user" '.users[$u].jwt.algorithm     // "ES256"' "$CONFIG")
+        priv=$(jq -r --arg u "$user" '.users[$u].jwt.private_key'              "$CONFIG")
+        kid=$(jq -r  --arg u "$user" '.users[$u].jwt.kid             // $u'    "$CONFIG")
+        exp=$(jq -r  --arg u "$user" '.users[$u].jwt.exp_duration_minutes // 60' "$CONFIG")
+        echo "(JWT mode — alg=$alg, kid=$kid, exp=${exp} min)"
+        echo
+        hostname="$PUBLIC_URL" database="$db" passphrase="$passphrase" \
+            auth_mode="jwt" \
+            jwt_algorithm="$alg" jwt_key="$priv" jwt_kid="$kid" \
+            jwt_sub="$user" jwt_exp_duration="$exp" \
+            deno run -A --quiet /opt/obsync/generate_setupuri.ts
+    else
+        local pw
+        pw=$(jq -r --arg u "$user" '.users[$u].password // empty' "$CONFIG")
+        [ -z "$pw" ] && die "user '$user' has neither jwt block nor password set"
+        echo "(HTTP Basic mode)"
+        echo
+        hostname="$PUBLIC_URL" database="$db" passphrase="$passphrase" \
+            auth_mode="basic" username="$user" password="$pw" \
+            deno run -A --quiet /opt/obsync/generate_setupuri.ts
+    fi
     echo
     echo "Hand the URI and the uri_passphrase to the user over DIFFERENT"
     echo "channels (URI via clipboard/email, passphrase typed/spoken)."

--- a/apps/obsync/scripts/provision.sh
+++ b/apps/obsync/scripts/provision.sh
@@ -6,7 +6,14 @@
 # The config secret JSON shape:
 #   {
 #     "users": {
-#       "alice": { "password": "...", "e2ee_passphrase": "..." },
+#       "alice": {
+#         "password": "...",
+#         "e2ee_passphrase": "...",
+#         "jwt": {                              # optional
+#           "public_key": "-----BEGIN PUBLIC KEY-----\n...\n",
+#           "algorithm":  "ES256"               # or ES512
+#         }
+#       },
 #       ...
 #     },
 #     "shared_vaults": {
@@ -15,9 +22,9 @@
 #     }
 #   }
 #
-# E2EE passphrases are not used by CouchDB itself — they're handed to the
-# `obsync setup-uri` command later. They live in the same config so the
-# image has a single source of truth.
+# E2EE passphrases and `jwt.private_key` (if any) are not consumed here —
+# they're handed to the `obsync setup-uri` command later. They live in the
+# same config so the image has a single source of truth.
 
 set -eu
 
@@ -90,7 +97,39 @@ jq -r '(.users // {}) | to_entries[] | "\(.key)\t\(.value.password)"' "$CONFIG" 
     esac
 done
 
-# 3. Ensure each shared vault exists with declared membership.
+# 3. Install / refresh per-user JWT public keys via REST.
+#    [jwt_keys] ec:<kid> = <public-key-PEM>
+#    The kid we use is the username — keeps things simple, one key per user.
+#    CouchDB's config storage rejects multi-line PEM strings ("Invalid
+#    configuration value"), so newlines must be escaped as the 2-char
+#    sequence \n in the JSON-encoded value (Fauxton uses the same trick).
+jq -c '(.users // {}) | to_entries[]
+       | select(.value.jwt? != null)
+       | {name: .key, alg: .value.jwt.algorithm, key: .value.jwt.public_key}' "$CONFIG" \
+| while IFS= read -r row; do
+    [ -z "$row" ] && continue
+    name=$(printf '%s' "$row" | jq -r '.name')
+    pem=$(printf '%s' "$row"  | jq -r '.key')
+    alg=$(printf '%s' "$row"  | jq -r '.alg // "ES256"')
+
+    case "$alg" in
+        ES256|ES512) family=ec ;;
+        *) log "WARN: user $name has unsupported jwt algorithm '$alg'; skipping"; continue ;;
+    esac
+
+    log "installing JWT public key for '$name' (alg=$alg, kid=$name)"
+    json_body=$(jq -nc --arg p "$pem" '$p | gsub("\n"; "\\n")')
+    code=$(printf '%s' "$json_body" | curl -s -o /dev/null -w '%{http_code}' \
+        -u "$ADMIN_USER:$ADMIN_PASS" -X PUT \
+        -H 'content-type: application/json' \
+        --data-binary @- "$URL/_node/_local/_config/jwt_keys/${family}:${name}")
+    case "$code" in
+        200) ;;
+        *)   log "WARN: PUT jwt_keys/${family}:${name} returned $code" ;;
+    esac
+done
+
+# 4. Ensure each shared vault exists with declared membership.
 jq -r '(.shared_vaults // {}) | to_entries[]
        | "\(.key)\t\(.value.members | join(","))"' "$CONFIG" \
 | while IFS=$'\t' read -r vault members; do


### PR DESCRIPTION
## Summary
- LiveSync clients authenticate via per-user JWT (ES256 / ES512); admin / curl / Fauxton / healthcheck stay on HTTP Basic + cookie
- Critical safety override: \`jwt_auth.roles_claim_name = _astra.roles\` so LiveSync's hardcoded \`_couchdb.roles=["_admin"]\` is ignored — without this, every LiveSync client gets full admin
- Provisioner installs each user's public key into \`[jwt_keys] ec:<username>\` via REST (newline escape required: literal \`\\n\`)
- New custom \`generate_setupuri.ts\` supports both \`auth_mode=basic\` and \`auth_mode=jwt\`; CLI auto-selects JWT when the user has \`jwt.private_key\` in the provisioning config

## Test plan
- [x] Build passes; CST 13/13 pass
- [x] End-to-end smoke with EC P-256 keypair: provisioner installs key, setup-uri returns JWT URI for alice; falls back to Basic for bob; shared-vault setup URI works in JWT mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)