### PR TITLE
feat(astrapdf): Russian OCR + _FILE secret support

### DIFF
--- a/apps/astrapdf/Dockerfile
+++ b/apps/astrapdf/Dockerfile
@@ -25,7 +25,19 @@ COPY --from=agent /build/target/astrapdf-agent.jar ${AGENT_PATH}/astrapdf-agent.
 RUN cp /app/lib/byte-buddy-*.jar ${AGENT_PATH}/byte-buddy.jar && \
     chmod 444 ${AGENT_PATH}/astrapdf-agent.jar ${AGENT_PATH}/byte-buddy.jar
 
+# The fat image ships only English tessdata; bake in Russian OCR (fast variant,
+# matching upstream's eng choice) so OCR ru/en works offline with no startup pull.
+RUN curl -fsSL -o /usr/share/tesseract-ocr/5/tessdata/rus.traineddata \
+      https://github.com/tesseract-ocr/tessdata_fast/raw/main/rus.traineddata && \
+    chmod 444 /usr/share/tesseract-ocr/5/tessdata/rus.traineddata
+
 # JDK_JAVA_OPTIONS is honoured by the java launcher itself, independent of the
 # image entrypoint and of JAVA_CUSTOM_OPTS (left free for the operator's heap
 # settings in the stack).
 ENV JDK_JAVA_OPTIONS="-javaagent:${AGENT_PATH}/astrapdf-agent.jar"
+
+# Generic "secrets via *_FILE" support (Stirling has none upstream), then chain
+# into the stock init. Lets any setting come from a Docker/Swarm secret file.
+COPY secrets-entrypoint.sh /scripts/secrets-entrypoint.sh
+RUN chmod 555 /scripts/secrets-entrypoint.sh
+ENTRYPOINT ["tini", "--", "/scripts/secrets-entrypoint.sh"]

--- a/apps/astrapdf/secrets-entrypoint.sh
+++ b/apps/astrapdf/secrets-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Generic Docker "secrets via file" support for AstraPDF.
+#
+# Stirling-PDF has no native _FILE convention. This wrapper implements the
+# common one: for every environment variable named <NAME>_FILE whose value is a
+# readable file, it exports <NAME> with the file's (trimmed) contents, then hands
+# off to the original Stirling entrypoint. Lets any setting be supplied as a
+# Docker/Swarm secret, e.g.:
+#
+#   SYSTEM_DATASOURCE_PASSWORD_FILE=/run/secrets/astrapdf_db_password
+#   SECURITY_OAUTH2_CLIENTSECRET_FILE=/run/secrets/astrapdf_oidc_client_secret
+#
+# A directly-set <NAME> is overridden by <NAME>_FILE when the file exists.
+set -e
+
+echo "AstraPDF: resolving *_FILE secrets into environment..."
+for v in $(env | sed -n 's/^\([A-Za-z_][A-Za-z0-9_]*\)_FILE=.*/\1_FILE/p'); do
+    target=${v%_FILE}
+    file=$(eval printf '%s' "\"\$$v\"")
+    if [ -n "$file" ] && [ -f "$file" ]; then
+        export "$target=$(tr -d '\n\r' < "$file")"
+        echo "  ✓ ${target} ← ${file}"
+    else
+        echo "  ⚠ ${v} is set but '${file}' is not a readable file"
+    fi
+done
+
+# Hand off to the stock Stirling-PDF init (JDK_JAVA_OPTIONS carries our agent).
+exec /scripts/init.sh

--- a/apps/astrapdf/tests.yaml
+++ b/apps/astrapdf/tests.yaml
@@ -2,6 +2,16 @@ file:
   /var/agent/astrapdf-agent.jar:
     exists: true
     mode: "0444"
+  /var/agent/byte-buddy.jar:
+    exists: true
+    mode: "0444"
+  /scripts/secrets-entrypoint.sh:
+    exists: true
+  # Russian OCR baked in alongside the stock English data
+  /usr/share/tesseract-ocr/5/tessdata/rus.traineddata:
+    exists: true
+  /usr/share/tesseract-ocr/5/tessdata/eng.traineddata:
+    exists: true
 
 addr:
   tcp://localhost:8080:


### PR DESCRIPTION
Adds rus OCR data and generic `*_FILE` secret resolution to the AstraPDF image. Validated locally: OCR eng+rus, `_FILE` resolver, ENTERPRISE tier intact under the new entrypoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)