### PR TITLE
astrapdf: build patched proprietary jar from fork (step-ca user-cert issuer)

### DIFF
--- a/apps/astrapdf/Dockerfile
+++ b/apps/astrapdf/Dockerfile
@@ -1,9 +1,13 @@
 # syntax=docker/dockerfile:1
 # check=skip=InvalidDefaultArgInFrom
 
-# Global build arg — declared before the first FROM so it is visible to the
-# stage 2 base image reference below.
+# Global build args — declared before the first FROM so they are visible to the
+# stage base image references below.
 ARG VERSION
+# SOURCE_REF is the git ref (our fork tag, e.g. astrapdf-2.11.0) carrying the
+# AstraPDF patch set on top of upstream VERSION. STIRLING_REPO is our fork.
+ARG SOURCE_REF
+ARG STIRLING_REPO=https://github.com/mrkhachaturov/Stirling-PDF.git
 
 # --- Stage 1: build the license agent from source ---------------------------
 FROM docker.io/library/maven:3.9-eclipse-temurin-21 AS agent
@@ -11,12 +15,57 @@ WORKDIR /build
 COPY agent/ .
 RUN mvn -q -B -e -DskipTests package
 
-# --- Stage 2: overlay the agent onto the official "fat" image ---------------
+# --- Stage 2: build the patched proprietary jar from our fork ---------------
+# The AstraPDF patch set is currently backend-only (per-user signing certificate
+# issuer / step-ca enrolment), living entirely in the proprietary module. We
+# compile ONLY that module from the fork at SOURCE_REF and swap its jar into the
+# official fat image below — no full Stirling rebuild, the heavy upstream image
+# (frontend, OCR, LibreOffice) is reused as-is.
+#
+# NOTE: this jar-overlay is valid only while the patch stays backend-only and the
+# fork is rebased on the SAME upstream tag as VERSION (so the jar filename/version
+# matches and the Spring Boot classpath index still resolves it). The moment the
+# patch touches the frontend or core/common, replace this stage with a full fat
+# build (docker/embedded/Dockerfile.fat) and FROM that instead of the line below.
+FROM docker.io/library/gradle:9.3.1-jdk25 AS patch
+WORKDIR /src
+ARG SOURCE_REF
+ARG STIRLING_REPO
+ARG STIRLING_REPO_API=https://api.github.com/repos/mrkhachaturov/Stirling-PDF
+# Cache-bust for a MOVED tag: SOURCE_REF (e.g. astrapdf-2.11.0) is re-pointed in place as the patch
+# iterates on the same upstream base. The git-fetch layer below would otherwise stay cached on its
+# unchanged command string and serve stale code. This ADD pulls the ref's current commit metadata,
+# whose body changes when the tag moves, invalidating the fetch + build layers. No effect on a
+# first/uncached build.
+ADD "${STIRLING_REPO_API}/commits/${SOURCE_REF}" /tmp/stirling-ref.json
+RUN git init -q . \
+    && git remote add origin "${STIRLING_REPO}" \
+    && git fetch --depth 1 origin "${SOURCE_REF}" \
+    && git checkout -q FETCH_HEAD
+RUN DISABLE_ADDITIONAL_FEATURES=false gradle :proprietary:jar \
+      -x test -x spotlessApply -x spotlessCheck --no-daemon
+
+# --- Stage 3: overlay onto the official "fat" image -------------------------
 # The fat image already bundles OCR (Tesseract + OCRmyPDF), LibreOffice and all
-# runtime dependencies. We only inject a -javaagent; nothing is rebuilt.
+# runtime dependencies. We inject the patched jar + a -javaagent; nothing else is
+# rebuilt.
 FROM docker.io/stirlingtools/stirling-pdf:${VERSION}-fat
 
+ARG VERSION
 USER root
+
+# Swap in the patched proprietary jar. Built on the SAME upstream VERSION, so the
+# jar bundled in the image (proprietary-<VERSION>[-plain].jar) keeps its filename
+# and the Spring Boot classpath index still resolves it — we only replace its
+# bytes. Matched by glob to stay agnostic to Spring Boot's '-plain' classifier;
+# the guards fail the build loudly rather than silently no-op'ing.
+COPY --from=patch /src/app/proprietary/build/libs/proprietary-${VERSION}*.jar /tmp/proprietary.jar
+RUN set -eu; \
+    matches="$(find /app -name "proprietary-${VERSION}*.jar")"; \
+    count="$(printf '%s\n' "${matches}" | grep -c . || true)"; \
+    [ "${count}" = "1" ] || { echo "expected exactly one proprietary jar in /app, found: ${matches:-none}"; exit 1; }; \
+    cp /tmp/proprietary.jar "${matches}"; \
+    rm /tmp/proprietary.jar
 
 ENV AGENT_PATH=/var/agent
 COPY --from=agent /build/target/astrapdf-agent.jar ${AGENT_PATH}/astrapdf-agent.jar

--- a/apps/astrapdf/docker-bake.hcl
+++ b/apps/astrapdf/docker-bake.hcl
@@ -5,6 +5,20 @@ variable "VERSION" {
   default = "2.11.0"
 }
 
+# SOURCE_REF is the git ref on our fork carrying the AstraPDF patch set, applied
+# on top of upstream VERSION. Pinned to a tag for reproducibility (the build
+# fetches exactly this ref). Bump when re-cutting the patch — rebase the fork
+# branch onto a newer upstream tag, push a new astrapdf-<version> tag, and point
+# this (and VERSION) at it. Drop SOURCE_REF entirely if upstream merges the PR.
+variable "SOURCE_REF" {
+  default = "astrapdf-2.11.0"
+}
+
+# Fork the patched Stirling source is fetched from at build time.
+variable "STIRLING_REPO" {
+  default = "https://github.com/mrkhachaturov/Stirling-PDF.git"
+}
+
 variable "SOURCE" {
   default = "https://github.com/astrateam-net/containers"
 }
@@ -16,10 +30,13 @@ group "default" {
 target "image" {
   inherits = ["docker-metadata-action"]
   args = {
-    VERSION = "${VERSION}"
+    VERSION       = "${VERSION}"
+    SOURCE_REF    = "${SOURCE_REF}"
+    STIRLING_REPO = "${STIRLING_REPO}"
   }
   labels = {
-    "org.opencontainers.image.source" = "${SOURCE}"
+    "org.opencontainers.image.source"   = "${SOURCE}"
+    "org.opencontainers.image.revision" = "${SOURCE_REF}"
   }
 }
 


### PR DESCRIPTION
Builds AstraPDF with the **per-user signing certificate issuer** patch (step-ca enrolment over OIDC) from our Stirling-PDF fork.

## What changed
- `apps/astrapdf/Dockerfile`: new lightweight **patch stage** — fetches the fork at `SOURCE_REF`, builds only the `proprietary` module, and swaps its jar into the official `stirlingtools/stirling-pdf:${VERSION}-fat`. No full Stirling rebuild (heavy upstream image reused as-is).
- `apps/astrapdf/docker-bake.hcl`: `SOURCE_REF` (moving tag `astrapdf-2.11.0`, rebased on upstream `v2.11.0`), `STIRLING_REPO` (our fork). Mirrors the `newt-swarm` pattern.
- GitHub-API `ADD` cache-busts the git fetch so re-pointing the tag in place forces a fresh checkout.

## Verified locally
- `just local-build astrapdf` builds the image OK; patched classes confirmed in the jar; container boots `{"status":"UP"}` in both default (`selfsigned`) and `stepca` modes (Spring context wires).

## Notes
- Backend-only patch → jar-overlay is sufficient. When it grows to touch frontend/core, switch the stage to a full `docker/embedded/Dockerfile.fat` build.
- Fork docs: `USERCERT_ISSUER.md`. CA-side contract: swarm `docs/CA/stepca-ceremony.md` §11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)