### PR TITLE
feat(authentik): add server image with cap_net_bind_service

### DIFF
--- a/apps/authentik/Dockerfile
+++ b/apps/authentik/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+# check=skip=InvalidDefaultArgInFrom
+
+# Authentik server with cap_net_bind_service granted on the binary, so the
+# non-root (uid 1000) process can bind privileged ports (e.g. 80/443) directly
+# without running as root or relying on an external port-forwarder.
+#
+# Thin overlay on the upstream image — VERSION is supplied by docker-bake.hcl.
+
+ARG VERSION
+
+FROM ghcr.io/goauthentik/server:${VERSION}
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends libcap2-bin \
+ && setcap cap_net_bind_service+ep /usr/bin/authentik-server \
+ && apt-get purge -y libcap2-bin && rm -rf /var/lib/apt/lists/*
+USER 1000

--- a/apps/authentik/docker-bake.hcl
+++ b/apps/authentik/docker-bake.hcl
@@ -1,0 +1,37 @@
+target "docker-metadata-action" {}
+
+variable "VERSION" {
+  // renovate: datasource=docker depName=ghcr.io/goauthentik/server
+  default = "2026.5.2"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/goauthentik/authentik"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}

--- a/apps/authentik/tests.yaml
+++ b/apps/authentik/tests.yaml
@@ -1,0 +1,26 @@
+schemaVersion: "2.0.0"
+
+# Structural test only — the authentik server needs PostgreSQL + Redis to run,
+# so we verify the overlay (binary present + capability persisted) rather than
+# booting the app.
+
+fileExistenceTests:
+  - name: authentik-server binary
+    path: /usr/bin/authentik-server
+    shouldExist: true
+
+commandTests:
+  - name: authentik-server is executable
+    command: sh
+    args: ["-lc", "test -x /usr/bin/authentik-server"]
+    exitCode: 0
+
+  # The setcap'd security.capability xattr must survive into the final layer.
+  # python3 ships in the authentik image; os.getxattr raises (non-zero) if the
+  # capability is absent, so exitCode 0 proves cap_net_bind_service is attached.
+  - name: cap_net_bind_service attached to binary
+    command: sh
+    args:
+      - "-lc"
+      - "python3 -c \"import os; os.getxattr('/usr/bin/authentik-server', 'security.capability')\""
+    exitCode: 0


### PR DESCRIPTION
## What

New `apps/authentik/` — a thin overlay on upstream `ghcr.io/goauthentik/server` that grants `cap_net_bind_service+ep` to `/usr/bin/authentik-server`, so the non-root (uid 1000) process can bind privileged ports (80/443) directly without root or an external port-forwarder.

## Files

- **Dockerfile** — `setcap` the binary, then purge `libcap2-bin` and drop back to `USER 1000`.
- **docker-bake.hcl** — `VERSION=2026.5.2`, Renovate `datasource=docker depName=ghcr.io/goauthentik/server`; all three targets, amd64+arm64.
- **tests.yaml** — CST (structure-only; authentik needs Postgres+Redis to boot): binary exists, executable, and the `security.capability` xattr survives the purge into the final layer.

## Verification

Local `just local-build authentik`: build OK, all 3 CST tests pass — including the capability-xattr check confirming `setcap` persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)