### PR TITLE
feat(apps/dev): browser-RDP authority endpoint for the Coder fork

### DIFF
--- a/apps/dev/Dockerfile
+++ b/apps/dev/Dockerfile
@@ -67,6 +67,16 @@ RUN git init -q . \
 # build loudly if a patch does not match the pinned VERSION.
 COPY patches/ /patches/
 RUN for p in /patches/*.patch; do echo "applying $p"; git apply --verbose "$p"; done
+
+# Browser-RDP authority: the coderd adapters + launch endpoint (package coderd,
+# version-robust new files) backing the dev-kit jetbroker core, plus the module
+# dependency. The route registration itself rides in patches/ (version-coupled).
+ARG DEV_KIT_VERSION=v0.2.0
+COPY overlay/coderd/ ./coderd/
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go get "github.com/astrateam-net/dev-kit@${DEV_KIT_VERSION}" \
+    && go mod tidy
+
 COPY --from=site /src/site/out ./site/out
 
 # Build the slim agent/CLI binaries the server serves at /bin/, then pack them

--- a/apps/dev/overlay/coderd/rdp_adapters.go
+++ b/apps/dev/overlay/coderd/rdp_adapters.go
@@ -1,0 +1,255 @@
+package coderd
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/astrateam-net/dev-kit/jetbroker"
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/workspaceapps/appurl"
+)
+
+// rdp_adapters.go backs the four jetbroker seams (ports.go) with Coder data,
+// all keyed by workspace id and read server-side. The HTTP endpoint
+// (rdp_launch.go) owner-gates the request first; these reads then run as the
+// system actor so the broker can read the workspace's own params/metadata
+// regardless of the caller's fine-grained RBAC.
+
+// rdpIdentity resolves the AD login: the rdp_username build parameter if set,
+// else the workspace owner's Coder username (the AD sAMAccountName synced via
+// Authentik). The down-level DOMAIN\user form is built by the jetbroker core
+// from Config.Realm.
+type rdpIdentity struct {
+	db            database.Store
+	usernameParam string
+}
+
+func (a rdpIdentity) Resolve(ctx context.Context, req jetbroker.LaunchRequest) (jetbroker.Identity, error) {
+	wsID, err := uuid.Parse(req.WorkspaceID)
+	if err != nil {
+		return jetbroker.Identity{}, xerrors.Errorf("parse workspace id: %w", err)
+	}
+	sctx := dbauthz.AsSystemRestricted(ctx)
+
+	ws, err := a.db.GetWorkspaceByID(sctx, wsID)
+	if err != nil {
+		return jetbroker.Identity{}, xerrors.Errorf("get workspace: %w", err)
+	}
+
+	params, err := latestBuildParams(sctx, a.db, wsID)
+	if err != nil {
+		return jetbroker.Identity{}, err
+	}
+
+	username := params[a.usernameParam]
+	if username == "" {
+		owner, err := a.db.GetUserByID(sctx, ws.OwnerID)
+		if err != nil {
+			return jetbroker.Identity{}, xerrors.Errorf("get workspace owner: %w", err)
+		}
+		username = owner.Username
+	}
+
+	return jetbroker.Identity{UserID: ws.OwnerID.String(), Username: username}, nil
+}
+
+// rdpTarget resolves the RDP target host from the coder.rdp.target resource
+// metadata key. Host only; the jetbroker core defaults the port to 3389.
+type rdpTarget struct {
+	db  database.Store
+	key string
+}
+
+func (a rdpTarget) Resolve(ctx context.Context, workspaceID string) (string, error) {
+	wsID, err := uuid.Parse(workspaceID)
+	if err != nil {
+		return "", xerrors.Errorf("parse workspace id: %w", err)
+	}
+	md, err := resourceMetadata(dbauthz.AsSystemRestricted(ctx), a.db, wsID)
+	if err != nil {
+		return "", err
+	}
+	target := md[a.key]
+	if target == "" {
+		return "", xerrors.Errorf("workspace declares no %q metadata", a.key)
+	}
+	return target, nil
+}
+
+// rdpGateways resolves the gateway farm from the coder.rdp.gateways resource
+// metadata key, a JSON list of {url, weight, app}. Per member:
+//   - url    INTERNAL gateway address: jetbroker uses it for /jet/heartbeat (selection)
+//            and /jet/preflight (server-side injection). The gateway uuid is discovered
+//            from /jet/heartbeat, never declared.
+//   - weight DVLS-style load-balancing weight.
+//   - app    the slug of a (hidden) subdomain coder_app pointing at this gateway. When set
+//            and the deployment has a wildcard app host, the BROWSER is sent to that app's
+//            Coder subdomain (slug--agent--workspace--owner.<wildcard>) instead of url, so a
+//            remote browser reaches the internal gateway via the Coder subdomain proxy.
+type rdpGateways struct {
+	db          database.Store
+	key         string
+	appHostname string // the deployment wildcard app host, e.g. "*.example.com" ("" disables subdomains)
+}
+
+func (a rdpGateways) Resolve(ctx context.Context, workspaceID string) ([]jetbroker.Gateway, error) {
+	wsID, err := uuid.Parse(workspaceID)
+	if err != nil {
+		return nil, xerrors.Errorf("parse workspace id: %w", err)
+	}
+	sctx := dbauthz.AsSystemRestricted(ctx)
+
+	md, err := resourceMetadata(sctx, a.db, wsID)
+	if err != nil {
+		return nil, err
+	}
+	raw := md[a.key]
+	if raw == "" {
+		return nil, xerrors.Errorf("workspace declares no %q metadata", a.key)
+	}
+
+	var declared []struct {
+		URL    string `json:"url"`
+		Weight int    `json:"weight"`
+		App    string `json:"app"`
+	}
+	if err := json.Unmarshal([]byte(raw), &declared); err != nil {
+		return nil, xerrors.Errorf("parse %q metadata: %w", a.key, err)
+	}
+
+	// Resolve the subdomain context once (only when subdomains are usable and at least one
+	// member declares an app). Without a wildcard host or an app slug the browser uses the
+	// gateway's own url (the directly-reachable case, e.g. a single LAN gateway).
+	var agentName, wsName, owner string
+	if a.appHostname != "" {
+		for _, g := range declared {
+			if g.App != "" {
+				agentName, wsName, owner, err = a.subdomainContext(sctx, wsID)
+				if err != nil {
+					return nil, err
+				}
+				break
+			}
+		}
+	}
+
+	gateways := make([]jetbroker.Gateway, 0, len(declared))
+	for _, g := range declared {
+		gw := jetbroker.Gateway{BaseURL: g.URL, Weight: g.Weight}
+		if g.App != "" && agentName != "" {
+			sub := appurl.ApplicationURL{
+				AppSlugOrPort: g.App,
+				AgentName:     agentName,
+				WorkspaceName: wsName,
+				Username:      owner,
+			}.String()
+			gw.BrowserURL = "https://" + strings.Replace(a.appHostname, "*", sub, 1)
+		}
+		gateways = append(gateways, gw)
+	}
+	return gateways, nil
+}
+
+// subdomainContext returns the agent/workspace/owner names used to build a subdomain app host
+// (slug--agent--workspace--owner.<wildcard>) for this workspace. The caller supplies the
+// authorization context.
+func (a rdpGateways) subdomainContext(ctx context.Context, wsID uuid.UUID) (agentName, wsName, owner string, err error) {
+	ws, err := a.db.GetWorkspaceByID(ctx, wsID)
+	if err != nil {
+		return "", "", "", xerrors.Errorf("get workspace: %w", err)
+	}
+	build, err := a.db.GetLatestWorkspaceBuildByWorkspaceID(ctx, wsID)
+	if err != nil {
+		return "", "", "", xerrors.Errorf("get latest build: %w", err)
+	}
+	resources, err := a.db.GetWorkspaceResourcesByJobID(ctx, build.JobID)
+	if err != nil {
+		return "", "", "", xerrors.Errorf("get build resources: %w", err)
+	}
+	ids := make([]uuid.UUID, 0, len(resources))
+	for _, res := range resources {
+		ids = append(ids, res.ID)
+	}
+	agents, err := a.db.GetWorkspaceAgentsByResourceIDs(ctx, ids)
+	if err != nil {
+		return "", "", "", xerrors.Errorf("get workspace agents: %w", err)
+	}
+	if len(agents) == 0 {
+		return "", "", "", xerrors.New("workspace has no agent to host the gateway subdomain app")
+	}
+	return agents[0].Name, ws.Name, ws.OwnerUsername, nil
+}
+
+// rdpSecret reads the real RDP password from the workspace's rdp_password build
+// parameter, keyed by workspace id (not by calling user).
+type rdpSecret struct {
+	db database.Store
+}
+
+func (a rdpSecret) Get(ctx context.Context, workspaceID, name string) (string, error) {
+	wsID, err := uuid.Parse(workspaceID)
+	if err != nil {
+		return "", xerrors.Errorf("parse workspace id: %w", err)
+	}
+	params, err := latestBuildParams(dbauthz.AsSystemRestricted(ctx), a.db, wsID)
+	if err != nil {
+		return "", err
+	}
+	value, ok := params[name]
+	if !ok {
+		return "", xerrors.Errorf("workspace declares no %q parameter", name)
+	}
+	return value, nil
+}
+
+// latestBuildParams returns the latest build's parameters as name->value. The
+// caller supplies the authorization context.
+func latestBuildParams(ctx context.Context, db database.Store, wsID uuid.UUID) (map[string]string, error) {
+	build, err := db.GetLatestWorkspaceBuildByWorkspaceID(ctx, wsID)
+	if err != nil {
+		return nil, xerrors.Errorf("get latest build: %w", err)
+	}
+	params, err := db.GetWorkspaceBuildParameters(ctx, build.ID)
+	if err != nil {
+		return nil, xerrors.Errorf("get build parameters: %w", err)
+	}
+	out := make(map[string]string, len(params))
+	for _, p := range params {
+		out[p.Name] = p.Value
+	}
+	return out, nil
+}
+
+// resourceMetadata returns the latest build's resource metadata as key->value,
+// flattened across every resource in the build (coder_metadata may attach to
+// any resource). The caller supplies the authorization context.
+func resourceMetadata(ctx context.Context, db database.Store, wsID uuid.UUID) (map[string]string, error) {
+	build, err := db.GetLatestWorkspaceBuildByWorkspaceID(ctx, wsID)
+	if err != nil {
+		return nil, xerrors.Errorf("get latest build: %w", err)
+	}
+	resources, err := db.GetWorkspaceResourcesByJobID(ctx, build.JobID)
+	if err != nil {
+		return nil, xerrors.Errorf("get build resources: %w", err)
+	}
+	ids := make([]uuid.UUID, 0, len(resources))
+	for _, res := range resources {
+		ids = append(ids, res.ID)
+	}
+	metadata, err := db.GetWorkspaceResourceMetadataByResourceIDs(ctx, ids)
+	if err != nil {
+		return nil, xerrors.Errorf("get resource metadata: %w", err)
+	}
+	out := make(map[string]string, len(metadata))
+	for _, md := range metadata {
+		if md.Value.Valid {
+			out[md.Key] = md.Value.String
+		}
+	}
+	return out, nil
+}

--- a/apps/dev/overlay/coderd/rdp_adapters_internal_test.go
+++ b/apps/dev/overlay/coderd/rdp_adapters_internal_test.go
@@ -1,0 +1,181 @@
+package coderd
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/astrateam-net/dev-kit/jetbroker"
+	"github.com/coder/coder/v2/coderd/database"
+)
+
+// fakeRDPStore implements only the handful of database.Store methods the RDP
+// adapters call. The embedded nil interface satisfies the rest; any unexpected
+// call panics, which is the behavior we want in a focused test.
+type fakeRDPStore struct {
+	database.Store
+
+	ws        database.Workspace
+	owner     database.User
+	build     database.WorkspaceBuild
+	params    []database.WorkspaceBuildParameter
+	resources []database.WorkspaceResource
+	agents    []database.WorkspaceAgent
+	metadata  []database.WorkspaceResourceMetadatum
+}
+
+func (f *fakeRDPStore) GetWorkspaceAgentsByResourceIDs(_ context.Context, _ []uuid.UUID) ([]database.WorkspaceAgent, error) {
+	return f.agents, nil
+}
+
+func (f *fakeRDPStore) GetWorkspaceByID(_ context.Context, id uuid.UUID) (database.Workspace, error) {
+	require := f.ws.ID == id
+	if !require {
+		return database.Workspace{}, sql.ErrNoRows
+	}
+	return f.ws, nil
+}
+
+func (f *fakeRDPStore) GetUserByID(_ context.Context, id uuid.UUID) (database.User, error) {
+	if f.owner.ID != id {
+		return database.User{}, sql.ErrNoRows
+	}
+	return f.owner, nil
+}
+
+func (f *fakeRDPStore) GetLatestWorkspaceBuildByWorkspaceID(_ context.Context, wsID uuid.UUID) (database.WorkspaceBuild, error) {
+	if f.build.WorkspaceID != wsID {
+		return database.WorkspaceBuild{}, sql.ErrNoRows
+	}
+	return f.build, nil
+}
+
+func (f *fakeRDPStore) GetWorkspaceBuildParameters(_ context.Context, buildID uuid.UUID) ([]database.WorkspaceBuildParameter, error) {
+	if f.build.ID != buildID {
+		return nil, sql.ErrNoRows
+	}
+	return f.params, nil
+}
+
+func (f *fakeRDPStore) GetWorkspaceResourcesByJobID(_ context.Context, jobID uuid.UUID) ([]database.WorkspaceResource, error) {
+	if f.build.JobID != jobID {
+		return nil, sql.ErrNoRows
+	}
+	return f.resources, nil
+}
+
+func (f *fakeRDPStore) GetWorkspaceResourceMetadataByResourceIDs(_ context.Context, _ []uuid.UUID) ([]database.WorkspaceResourceMetadatum, error) {
+	return f.metadata, nil
+}
+
+func meta(key, value string) database.WorkspaceResourceMetadatum {
+	return database.WorkspaceResourceMetadatum{Key: key, Value: sql.NullString{String: value, Valid: true}}
+}
+
+func newFixture() *fakeRDPStore {
+	wsID := uuid.New()
+	ownerID := uuid.New()
+	buildID := uuid.New()
+	jobID := uuid.New()
+	resID := uuid.New()
+	return &fakeRDPStore{
+		ws:    database.Workspace{ID: wsID, OwnerID: ownerID, Name: "myws", OwnerUsername: "ceo"},
+		owner: database.User{ID: ownerID, Username: "ceo"},
+		build: database.WorkspaceBuild{ID: buildID, WorkspaceID: wsID, JobID: jobID},
+		params: []database.WorkspaceBuildParameter{
+			{Name: "rdp_password", Value: "s3cr3t"},
+		},
+		resources: []database.WorkspaceResource{{ID: resID, JobID: jobID}},
+		agents:    []database.WorkspaceAgent{{Name: "main", ResourceID: resID}},
+		metadata: []database.WorkspaceResourceMetadatum{
+			meta("coder.rdp.target", "win-host.example.com"),
+			meta("coder.rdp.gateways", `[{"url":"https://gw01.example.com:7171","weight":100},{"url":"https://gw02.example.com:7171","weight":50}]`),
+		},
+	}
+}
+
+func TestRDPIdentity(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("FallsBackToOwner", func(t *testing.T) {
+		t.Parallel()
+		f := newFixture()
+		id, err := rdpIdentity{db: f, usernameParam: "rdp_username"}.Resolve(ctx, jetbroker.LaunchRequest{WorkspaceID: f.ws.ID.String()})
+		require.NoError(t, err)
+		require.Equal(t, "ceo", id.Username)
+		require.Equal(t, f.owner.ID.String(), id.UserID)
+	})
+
+	t.Run("ParamWins", func(t *testing.T) {
+		t.Parallel()
+		f := newFixture()
+		f.params = append(f.params, database.WorkspaceBuildParameter{Name: "rdp_username", Value: "svc_account"})
+		id, err := rdpIdentity{db: f, usernameParam: "rdp_username"}.Resolve(ctx, jetbroker.LaunchRequest{WorkspaceID: f.ws.ID.String()})
+		require.NoError(t, err)
+		require.Equal(t, "svc_account", id.Username)
+	})
+}
+
+func TestRDPTarget(t *testing.T) {
+	t.Parallel()
+	f := newFixture()
+	host, err := rdpTarget{db: f, key: "coder.rdp.target"}.Resolve(context.Background(), f.ws.ID.String())
+	require.NoError(t, err)
+	require.Equal(t, "win-host.example.com", host)
+}
+
+// TestRDPGateways: no wildcard host + no app slug => the browser uses the gateway's own url
+// (BrowserURL stays empty). This is the directly-reachable case (e.g. a single LAN gateway).
+func TestRDPGateways(t *testing.T) {
+	t.Parallel()
+	f := newFixture()
+	gws, err := rdpGateways{db: f, key: "coder.rdp.gateways"}.Resolve(context.Background(), f.ws.ID.String())
+	require.NoError(t, err)
+	require.Equal(t, []jetbroker.Gateway{
+		{BaseURL: "https://gw01.example.com:7171", Weight: 100},
+		{BaseURL: "https://gw02.example.com:7171", Weight: 50},
+	}, gws)
+}
+
+// TestRDPGatewaysSubdomain: with a wildcard host + an app slug, the browser-facing URL becomes the
+// gateway's Coder subdomain (slug--agent--workspace--owner.<wildcard>), while BaseURL (heartbeat/
+// preflight) stays the internal gateway address.
+func TestRDPGatewaysSubdomain(t *testing.T) {
+	t.Parallel()
+	f := newFixture()
+	f.metadata = []database.WorkspaceResourceMetadatum{
+		meta("coder.rdp.gateways", `[{"url":"https://gw01.example.com:7171","weight":100,"app":"rdp-gw01"}]`),
+	}
+	gws, err := rdpGateways{db: f, key: "coder.rdp.gateways", appHostname: "*.example.com"}.Resolve(context.Background(), f.ws.ID.String())
+	require.NoError(t, err)
+	require.Equal(t, []jetbroker.Gateway{
+		{
+			BaseURL:    "https://gw01.example.com:7171",
+			Weight:     100,
+			BrowserURL: "https://rdp-gw01--main--myws--ceo.example.com",
+		},
+	}, gws)
+}
+
+func TestRDPSecret(t *testing.T) {
+	t.Parallel()
+	f := newFixture()
+	pw, err := rdpSecret{db: f}.Get(context.Background(), f.ws.ID.String(), "rdp_password")
+	require.NoError(t, err)
+	require.Equal(t, "s3cr3t", pw)
+
+	_, err = rdpSecret{db: f}.Get(context.Background(), f.ws.ID.String(), "missing")
+	require.Error(t, err)
+}
+
+func TestRDPTargetMissing(t *testing.T) {
+	t.Parallel()
+	f := newFixture()
+	f.metadata = nil
+	_, err := rdpTarget{db: f, key: "coder.rdp.target"}.Resolve(context.Background(), f.ws.ID.String())
+	require.Error(t, err)
+}

--- a/apps/dev/overlay/coderd/rdp_launch.go
+++ b/apps/dev/overlay/coderd/rdp_launch.go
@@ -1,0 +1,160 @@
+package coderd
+
+import (
+	"crypto/tls"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/astrateam-net/dev-kit/jetbroker"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// rdp_launch.go wires the in-house browser-RDP authority (the dev-kit jetbroker
+// core) into coderd. The endpoint mints provisioner-signed Devolutions Gateway
+// tokens, injects the real RDP credential into a farm gateway server-to-server
+// via /jet/preflight, and 302s the browser to the chosen gateway's webapp
+// launch page with a descriptor that NEVER carries the real password.
+//
+// The four jetbroker seams (identity, target, gateway farm, secret) are backed
+// by Coder data read by workspace id (rdp_adapters.go). The endpoint is owner
+// gated: only the workspace owner may launch (share=owner parity).
+
+var (
+	rdpBrokerOnce sync.Once
+	rdpBroker     *jetbroker.Broker
+	rdpBrokerErr  error
+)
+
+// rdpBrokerFor builds the jetbroker.Broker once from environment configuration,
+// backed by the Coder database. A misconfigured deployment fails per request
+// (the error is logged, the client gets a generic 502) rather than at boot, so
+// a Coder server without RDP configured still starts normally.
+func (api *API) rdpBrokerFor() (*jetbroker.Broker, error) {
+	rdpBrokerOnce.Do(func() {
+		// api.AppHostname is the deployment wildcard app host (e.g. "*.example.com"); it
+		// lets the gateway resolver build the browser-facing subdomain for the chosen gateway.
+		// Empty (no wildcard configured) => the browser uses the gateway's own url.
+		rdpBroker, rdpBrokerErr = buildRDPBroker(api.Database, api.AppHostname)
+	})
+	return rdpBroker, rdpBrokerErr
+}
+
+func buildRDPBroker(db database.Store, appHostname string) (*jetbroker.Broker, error) {
+	keyPath := os.Getenv("CODER_RDP_PROVISIONER_KEY")
+	if keyPath == "" {
+		return nil, xerrors.New("CODER_RDP_PROVISIONER_KEY is required (path to the provisioner private key PEM)")
+	}
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, xerrors.Errorf("read CODER_RDP_PROVISIONER_KEY: %w", err)
+	}
+	key, err := jetbroker.LoadProvisionerKey(keyPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	usernameParam := envOr("CODER_RDP_USERNAME_PARAM", "rdp_username")
+	cfg := jetbroker.Config{
+		ProvisionerKey:   key,
+		Realm:            os.Getenv("CODER_RDP_REALM"),
+		SecretName:       envOr("CODER_RDP_SECRET_PARAM", "rdp_password"),
+		RedirectMode:     true,
+		PlayerLaunchPath: envOr("CODER_RDP_LAUNCH_PATH", "/jet/webapp/client/launch"),
+	}
+	if ttl := os.Getenv("CODER_RDP_CREDENTIAL_TTL"); ttl != "" {
+		n, err := strconv.Atoi(ttl)
+		if err != nil {
+			return nil, xerrors.Errorf("CODER_RDP_CREDENTIAL_TTL must be an integer: %w", err)
+		}
+		cfg.CredentialTTL = n
+	}
+	// Farm gateways carry the publicly trusted wildcard cert, so TLS verifies by
+	// default. Opt-in skip for a private-CA test stand only.
+	if truthy(os.Getenv("CODER_RDP_TLS_INSECURE")) {
+		cfg.HTTPClient = &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, //nolint:gosec // test-stand opt-in
+		}
+	}
+
+	return jetbroker.New(
+		cfg,
+		rdpIdentity{db: db, usernameParam: usernameParam},
+		rdpTarget{db: db, key: envOr("CODER_RDP_TARGET_KEY", "coder.rdp.target")},
+		rdpSecret{db: db},
+		rdpGateways{db: db, key: envOr("CODER_RDP_GATEWAYS_KEY", "coder.rdp.gateways"), appHostname: appHostname},
+	)
+}
+
+// workspaceRDP is the launch endpoint. It is registered behind apiKeyMiddleware
+// and httpmw.ExtractWorkspaceParam, so the caller is authenticated and the
+// workspace is loaded. It authorizes the owner (share=owner), then delegates to
+// the jetbroker handler, which selects a gateway, injects the credential, and
+// 302s to the gateway webapp launch page.
+//
+// @Summary Launch a browser RDP session
+// @ID launch-a-browser-rdp-session
+// @Security CoderSessionToken
+// @Tags Workspaces
+// @Param workspace path string true "Workspace ID" format(uuid)
+// @Success 302
+// @Router /workspaces/{workspace}/rdp [get]
+// @x-apidocgen {"skip": true}
+func (api *API) workspaceRDP(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	ws := httpmw.WorkspaceParam(r)
+
+	// share=owner: only the workspace owner may launch RDP. The credential is
+	// bound to the workspace, so this gate prevents a non-owner from connecting
+	// under the configured account by guessing the workspace id.
+	if httpmw.APIKey(r).UserID != ws.OwnerID {
+		httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{
+			Message: "Workspace not found.",
+		})
+		return
+	}
+
+	broker, err := api.rdpBrokerFor()
+	if err != nil {
+		api.Logger.Error(ctx, "rdp broker unavailable", slog.Error(err))
+		httpapi.Write(ctx, rw, http.StatusBadGateway, codersdk.Response{
+			Message: "RDP is not available.",
+		})
+		return
+	}
+
+	// The jetbroker handler reads the workspace id from the "ws" query param and
+	// owns the redirect/descriptor encoding. Feed it the authorized workspace id
+	// from the path so the adapters resolve the right workspace server-side.
+	q := r.URL.Query()
+	q.Set("ws", ws.ID.String())
+	r.URL.RawQuery = q.Encode()
+	broker.Handler().ServeHTTP(rw, r)
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func truthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}

--- a/apps/dev/patches/0002-rdp-launch-route.patch
+++ b/apps/dev/patches/0002-rdp-launch-route.patch
@@ -1,0 +1,12 @@
+diff --git a/coderd/coderd.go b/coderd/coderd.go
+index 0000000..0000001 100644
+--- a/coderd/coderd.go
++++ b/coderd/coderd.go
+@@ -1811,6 +1811,7 @@
+ 				)
+ 				r.Get("/", api.workspace)
+ 				r.Patch("/", api.patchWorkspace)
++				r.Get("/rdp", api.workspaceRDP)
+ 				r.Route("/builds", func(r chi.Router) {
+ 					r.Get("/", api.workspaceBuilds)
+ 					r.Post("/", api.postWorkspaceBuilds)


### PR DESCRIPTION
## What

Adds an in-house **browser-RDP authority** to the `apps/dev` Coder fork: a `GET /api/v2/workspaces/{workspace}/rdp` endpoint that mints provisioner-signed Devolutions Gateway (Jet) tokens, injects the real RDP credential into a farm gateway **server-to-server** via `/jet/preflight`, and 302s the browser to a gateway webapp launch page with a descriptor that **never carries the real password**.

The portable core lives in the `github.com/astrateam-net/dev-kit` `jetbroker` module (pinned `v0.2.0`). This repo supplies only the Coder-specific glue.

## How it's wired

- **`overlay/coderd/rdp_adapters.go`** — backs the four jetbroker seams with Coder data, all read server-side by workspace id:
  - identity: `rdp_username` param, else workspace owner
  - target: `coder.rdp.target` resource metadata
  - gateways: `coder.rdp.gateways` JSON metadata (`{url, weight, app}`)
  - secret: `rdp_password` param
- **`overlay/coderd/rdp_launch.go`** — env-configured broker (built once), owner-gated handler (`share=owner` parity → 404 for non-owners).
- **`patches/0002-rdp-launch-route.patch`** — one-line route registration on the pristine `v2.34.0` tag.
- **`Dockerfile`** — copies the overlay and pins `DEV_KIT_VERSION=v0.2.0`.

### Browser vs. internal split (dev-kit v0.2.0)

When a gateway member declares an `app` slug and the deployment has a wildcard app host, the **browser** is sent to that app's Coder subdomain (`slug--agent--workspace--owner.<wildcard>`) which reverse-proxies through the agent to the internal gateway. The **server-side** legs (heartbeat selection, preflight injection) keep using the gateway's own internal address. A remote browser never needs to reach the gateway directly.

## Testing

- `go build` / `go vet` / unit tests green against published `dev-kit v0.2.0` (incl. `TestRDPGatewaysSubdomain`).
- **Live container test**: rebuilt `coder-dev:local` (new overlay + v0.2.0), ran it against a real Devolutions Gateway stand, and verified end-to-end:
  - 302 → `https://rdp-gw01--main--rdpsub--admin.<wildcard>/jet/webapp/client/launch#…`; decoded descriptor `gateway_url`/`kdc_proxy_url` both on the subdomain.
  - Gateway logs: `GET /jet/heartbeat 200` + `POST /jet/preflight 200` (target credential `DOMAIN\user`, password redacted; synthetic GUID proxy credential; ttl 900).
  - `gateway_name` in the descriptor is the heartbeat-discovered hostname — proof the broker selected the live internal gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)