### PR TITLE
build(apps/dev): russify the UI via the dev-kit coder-i18n factory

### DIFF
--- a/apps/dev/Dockerfile
+++ b/apps/dev/Dockerfile
@@ -46,6 +46,27 @@ RUN git init -q . \
 WORKDIR /src/site
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile
+
+# --- i18n (optional): Russian localization via the dev-kit coder-i18n factory -
+# Pulls the published factory and runs its DETERMINISTIC steps against this
+# checkout: the codemod wraps UI literals into Tolgee shapes, then bake injects
+# the provider + a language switcher + the pre-translated catalogs the factory
+# ships in dist/. Translation (Tolgee/OpenAI) is NOT run here — it happens
+# offline when strings change. Build the stock English frontend with
+# `--set image-local.args.I18N=` (empty).
+ARG DEV_KIT_VERSION=v0.3.0
+ARG I18N=ru
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    if [ -n "$I18N" ]; then \
+      git clone --depth 1 --branch "${DEV_KIT_VERSION}" \
+        https://github.com/astrateam-net/dev-kit.git /factory \
+      && ( cd /factory/coder-i18n \
+           && mkdir -p .upstream && ln -s /src .upstream/coder \
+           && pnpm install --frozen-lockfile \
+           && pnpm exec tsx codemod/wrap.ts \
+           && pnpm exec tsx codemod/inject-runtime.ts ) \
+      && pnpm add @tolgee/react@latest @tolgee/format-icu@latest ; \
+    fi
 RUN NODE_ENV=production pnpm build
 
 # --- Stage 2: patch + build slim agents + cross-compile the server ----------
@@ -71,7 +92,7 @@ RUN for p in /patches/*.patch; do echo "applying $p"; git apply --verbose "$p"; 
 # Browser-RDP authority: the coderd adapters + launch endpoint (package coderd,
 # version-robust new files) backing the dev-kit jetbroker core, plus the module
 # dependency. The route registration itself rides in patches/ (version-coupled).
-ARG DEV_KIT_VERSION=v0.2.0
+ARG DEV_KIT_VERSION=v0.3.0
 COPY overlay/coderd/ ./coderd/
 # Browser-RDP gateway direct-proxy helper (package workspaceapps; called by the
 # proxy branch in patches/0003). Version-robust, no new module deps.


### PR DESCRIPTION
## What

Integrates the published **`dev-kit@v0.3.0` coder-i18n factory** into the `apps/dev` image build, so the forked Coder ships a Russian UI for staff.

In Stage 1 (frontend), after the site `pnpm install` and before `pnpm build`, the build clones the factory and runs its **deterministic** steps against the pinned Coder checkout:
- **wrap** — ts-morph codemod wraps UI literals into Tolgee `<T>`/`t()` shapes (type-aware; skips `children: string` components),
- **bake** — injects the `<I18nProvider>`, a language switcher (User Settings → Appearance), and the **pre-translated** `dist/{en,ru}.json` catalogs the factory ships,
- adds `@tolgee/react` + `@tolgee/format-icu`.

Translation (Tolgee + OpenAI) is **not** run in the image — only the deterministic wrap/bake; catalogs are pre-baked offline when strings change. Russian is the default (`ARG I18N=ru`); build stock English with `--set image-local.args.I18N=`.

`DEV_KIT_VERSION` bumped `v0.2.0 → v0.3.0` (shared with the Go `go get` for jetbroker, which is unchanged in v0.3.0).

## Validated

Built `coder-dev:local` locally and ran it: the UI renders Russian by default and the language switcher works (User Settings → Внешний вид → «Язык · Language»).

🤖 Generated with [Claude Code](https://claude.com/claude-code)