### PR TITLE
feat(pangolin): EE fork with deterministic exit-node subdomains

### DIFF
--- a/apps/pangolin/Dockerfile
+++ b/apps/pangolin/Dockerfile
@@ -1,0 +1,89 @@
+# syntax=docker/dockerfile:1
+# Pangolin EE (postgresql) rebuilt from source with a deterministic exit-node
+# subdomain patch.
+#
+# WHY: stock Pangolin, with `use_subdomain: true`, assigns each exit node a
+# RANDOM `adjective-animal` label (server/db/names.ts) that only exists after the
+# gerbil registers — so you cannot pre-create its DNS record, which forces the EE
+# dynamic authoritative-DNS component. This fork derives the label deterministically
+# from the gerbil's own `reachableAt` host, so a static, operator-known name (e.g.
+# png01.wg.example.net) is used and you pre-create the DNS A records yourself.
+#
+# Patches (patches/, applied with `git apply` — the build FAILS LOUDLY on any
+# upstream drift from ${VERSION}, so version bumps are caught here, not at runtime):
+#   0001  createExitNode (EE): subEndpoint = deterministic label from reachableAt
+#         host; upstream random name kept as fallback when reachableAt is absent.
+#   0002  copyInConfig: with use_subdomain on, do NOT reset those per-node
+#         endpoints back to base_endpoint on every boot (copyInConfig runs each
+#         startup — without this the labels are wiped on the first restart).
+#
+# Build variant matches the upstream `ee-postgresql` image: BUILD=enterprise,
+# DATABASE=pg. Runner packaging mirrors upstream's own Dockerfile.
+
+ARG VERSION=1.19.4
+ARG NODE_VERSION=24
+
+# ---- fetch pristine upstream source at the tag, apply our patches ----
+FROM public.ecr.aws/docker/library/node:${NODE_VERSION}-slim AS source
+ARG VERSION
+ARG PANGOLIN_REPO=https://github.com/fosrl/pangolin.git
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN git init -q . \
+    && git remote add origin "${PANGOLIN_REPO}" \
+    && git fetch --depth 1 origin "refs/tags/${VERSION}" \
+    && git checkout -q FETCH_HEAD
+COPY patches/ /patches/
+RUN git apply --verbose /patches/*.patch \
+    && rm -rf /patches .git
+
+# ---- base toolchain (native deps for the npm build) ----
+FROM public.ecr.aws/docker/library/node:${NODE_VERSION}-slim AS base
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=source /app/package*.json ./
+
+# ---- full build (enterprise + postgresql) ----
+FROM base AS builder-dev
+ARG BUILD=enterprise
+ARG DATABASE=pg
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npm ci
+COPY --from=source /app ./
+RUN npm run set:$DATABASE \
+    && npm run set:$BUILD \
+    && npm run db:generate \
+    && npm run build \
+    && npm run build:cli \
+    && test -f dist/server.mjs
+
+# ---- production dependencies only ----
+FROM base AS builder
+RUN npm ci --omit=dev
+
+# ---- runner ----
+FROM public.ecr.aws/docker/library/node:${NODE_VERSION}-slim AS runner
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends curl tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder     /app/node_modules ./node_modules
+COPY --from=builder     /app/package.json ./package.json
+COPY --from=builder-dev /app/.next/standalone ./
+COPY --from=builder-dev /app/.next/static ./.next/static
+COPY --from=builder-dev /app/dist ./dist
+COPY --from=builder-dev /app/server/migrations ./dist/init
+COPY --from=builder-dev /app/cli/wrapper.sh /usr/local/bin/pangctl
+RUN chmod +x /usr/local/bin/pangctl ./dist/cli.mjs
+COPY --from=builder-dev /app/server/db/names.json ./dist/names.json
+COPY --from=builder-dev /app/server/db/ios_models.json ./dist/ios_models.json
+COPY --from=builder-dev /app/server/db/mac_models.json ./dist/mac_models.json
+COPY --from=builder-dev /app/public ./public
+
+# Matches the reference stack's compose healthcheck.
+HEALTHCHECK --interval=10s --timeout=10s --retries=15 \
+    CMD curl -f http://localhost:3001/api/v1/ || exit 1
+
+CMD ["npm", "run", "start"]

--- a/apps/pangolin/README.md
+++ b/apps/pangolin/README.md
@@ -1,0 +1,80 @@
+# pangolin
+
+`ghcr.io/astrateam-net/pangolin` — [Pangolin](https://github.com/fosrl/pangolin) **Enterprise
+(postgresql)**, rebuilt from a pinned upstream tag with a small patch series that makes exit-node
+**subdomains deterministic** instead of random.
+
+The build mirrors upstream's own packaging (`BUILD=enterprise`, `DATABASE=pg`, same Next.js +
+esbuild pipeline), so the result matches the published `fosrl/pangolin:ee-postgresql-<VERSION>`
+image outside the two patched functions.
+
+> **License:** `server/private/**` is Fossorial's proprietary Enterprise source. This image is
+> built and run under our own Enterprise license; treat the image accordingly.
+
+## Why a fork
+
+With `use_subdomain: true`, stock Pangolin gives each exit node a **random** `adjective-animal`
+label ([`server/db/names.ts`](https://github.com/fosrl/pangolin) `getUniqueExitNodeEndpointName`),
+generated only *after* the gerbil registers. You cannot pre-create a DNS record for a name you
+don't know yet — which is exactly why upstream pairs random labels with a **dynamic authoritative
+DNS** component (Pangolin DNS on :53 + NS delegation).
+
+We don't run that component. Our exit nodes have **static, operator-chosen names** (one Swarm
+service per node — see [`gerbil-traefik-s6`](../gerbil-traefik-s6/)), so we want the exit-node
+endpoint to be a name we already know and can pre-create in DNS ourselves.
+
+| | Stock EE (`use_subdomain: true`) | This fork |
+|---|---|---|
+| Exit-node label | random `swift-otter` (post-registration) | deterministic, from the gerbil's `reachableAt` host |
+| Endpoint | `swift-otter.wg.example.net` | `png01.wg.example.net` |
+| DNS record | needs Pangolin dynamic DNS / NS delegation | **you pre-create a static A record** |
+
+## What the patch does
+
+Two files, applied with `git apply` at build time (fails the build loudly on any upstream drift
+from `VERSION`). Full analysis: [`docs/pangolin-exit-node-subdomains.md`](../../../../../Gitlab/astrateam-net/Infra/net/tower/docs/pangolin-exit-node-subdomains.md).
+
+| Patch | File | Change |
+|-------|------|--------|
+| [`0001`](patches/0001-deterministic-exit-node-subdomain.patch) | `server/private/routers/gerbil/createExitNode.ts` (EE) | When `use_subdomain` is on, `subEndpoint` = the first host label of the gerbil's `reachableAt` (`http://png01:3004` → `png01`), lower-cased and DNS-sanitized. Falls back to the upstream random name if `reachableAt` is missing/unparseable. |
+| [`0002`](patches/0002-preserve-subdomain-endpoints-on-boot.patch) | `server/setup/copyInConfig.ts` | `copyInConfig` runs on **every** server start (`server/index.ts:37` → `runSetupFunctions` → `copyInConfig`) and resets any endpoint `!= base_endpoint` back to `base_endpoint`. With `use_subdomain` on, that reset is skipped so the `png0N` labels survive restarts (`listenPort` is still normalized). |
+
+**No gerbil fork needed.** The gerbil already reports `reachableAt`; the label is derived from it,
+so the identity anchor is the gerbil's stable WireGuard public key and the name is stable per node.
+
+## How to use it
+
+1. Set in Pangolin `config.yml`:
+   ```yaml
+   gerbil:
+     use_subdomain: true
+     base_endpoint: wg.example.net       # always the suffix
+     # exit_node_name: unset in HA (a single shared name collapses all nodes)
+   ```
+2. Name each gerbil service = the public label you want, and set `REACHABLE_AT` to match:
+   `REACHABLE_AT=http://png01:3004` ⇒ endpoint `png01.wg.example.net`.
+3. **Pre-create the DNS** yourself: `png01.wg.example.net A <tower01 public IP>`, etc.
+   No dynamic authoritative DNS required.
+
+## Build
+
+Four-stage [`Dockerfile`](Dockerfile): fetch upstream source at `${VERSION}` → `git apply patches/`
+→ `set:enterprise` + `set:pg` + full build → assemble runner (mirrors upstream's runner stage;
+context COPYs are pulled from the in-image source, not the build context).
+
+### Version (single `docker-bake.hcl` variable, Renovate-tracked)
+
+| Variable | Tracks | Datasource | Default |
+|---|---|---|---|
+| `VERSION` | upstream Pangolin release | `github-releases` → `fosrl/pangolin` | `1.19.4` |
+
+```bash
+mise run local-build pangolin     # build + container-structure-test
+```
+
+## Deploy
+
+Drop-in for `fosrl/pangolin:ee-postgresql-<VERSION>` — same runtime contract (Postgres + Valkey,
+`/app/config`, ports 3000/3001/3002/3003, `npm run start` runs migrations then the server). The
+only behavioural difference is exit-node endpoint naming, gated behind `use_subdomain: true`; with
+`use_subdomain: false` it is byte-for-byte upstream behaviour.

--- a/apps/pangolin/docker-bake.hcl
+++ b/apps/pangolin/docker-bake.hcl
@@ -1,0 +1,37 @@
+target "docker-metadata-action" {}
+
+# Upstream Pangolin release this fork is built from. Drives the image tag and the
+# git tag the source is fetched at (patches must match this version or the build
+# fails at `git apply`).
+variable "VERSION" {
+  // renovate: datasource=github-releases depName=fosrl/pangolin
+  default = "1.19.4"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/fosrl/pangolin"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output   = ["type=docker"]
+}
+
+target "image-all" {
+  inherits  = ["image"]
+  platforms = ["linux/amd64", "linux/arm64"]
+}

--- a/apps/pangolin/patches/0001-deterministic-exit-node-subdomain.patch
+++ b/apps/pangolin/patches/0001-deterministic-exit-node-subdomain.patch
@@ -1,0 +1,40 @@
+diff --git a/server/private/routers/gerbil/createExitNode.ts b/server/private/routers/gerbil/createExitNode.ts
+index 818c5f0..c8a9200 100644
+--- a/server/private/routers/gerbil/createExitNode.ts
++++ b/server/private/routers/gerbil/createExitNode.ts
+@@ -18,6 +18,21 @@ import { getNextAvailableSubnet } from "@server/lib/exitNodes";
+ import logger from "@server/logger";
+ import { eq } from "drizzle-orm";
+ 
++// FORK (astrateam): derive a deterministic exit-node subdomain label from the
++// gerbil's reachableAt host (e.g. http://png01:3004 -> "png01"), so operators
++// can pre-create static DNS records instead of relying on random labels served
++// by a dynamic authoritative DNS. Returns "" when reachableAt is missing or
++// unparseable, so the caller falls back to the upstream random generator.
++function deterministicExitNodeLabel(reachableAt: string | undefined): string {
++    if (!reachableAt) return "";
++    try {
++        const host = new URL(reachableAt).hostname;
++        return host.split(".")[0].toLowerCase().replace(/[^a-z0-9-]/g, "");
++    } catch {
++        return "";
++    }
++}
++
+ export async function createExitNode(
+     publicKey: string,
+     reachableAt: string | undefined
+@@ -35,7 +50,12 @@ export async function createExitNode(
+         const listenPort = config.getRawConfig().gerbil.start_port;
+         let subEndpoint = "";
+         if (config.getRawConfig().gerbil.use_subdomain) {
+-            subEndpoint = await getUniqueExitNodeEndpointName();
++            // FORK (astrateam): prefer the deterministic label derived from
++            // reachableAt; fall back to the upstream random adjective-animal
++            // name only when reachableAt is absent/unparseable.
++            subEndpoint =
++                deterministicExitNodeLabel(reachableAt) ||
++                (await getUniqueExitNodeEndpointName());
+         }
+ 
+         const exitNodeName =

--- a/apps/pangolin/patches/0002-preserve-subdomain-endpoints-on-boot.patch
+++ b/apps/pangolin/patches/0002-preserve-subdomain-endpoints-on-boot.patch
@@ -1,0 +1,34 @@
+diff --git a/server/setup/copyInConfig.ts b/server/setup/copyInConfig.ts
+index be37681..f57db5b 100644
+--- a/server/setup/copyInConfig.ts
++++ b/server/setup/copyInConfig.ts
+@@ -20,16 +20,24 @@ export async function copyInConfig() {
+     }
+ 
+     const exitNodeName = config.getRawConfig().gerbil.exit_node_name;
+-    if (exitNodeName) {
++    // FORK (astrateam): with use_subdomain the per-exit-node endpoints
++    // (<label>.base_endpoint, derived from reachableAt in createExitNode) are
++    // intentional and MUST survive restarts. copyInConfig runs on every boot,
++    // so we must NOT reset those endpoints back to base_endpoint here. listenPort
++    // is still normalized uniformly.
++    const useSubdomain = config.getRawConfig().gerbil.use_subdomain;
++    if (exitNodeName && !useSubdomain) {
+         await db
+             .update(exitNodes)
+             .set({ endpoint, listenPort })
+             .where(eq(exitNodes.name, exitNodeName));
+     } else {
+-        await db
+-            .update(exitNodes)
+-            .set({ endpoint })
+-            .where(ne(exitNodes.endpoint, endpoint));
++        if (!useSubdomain) {
++            await db
++                .update(exitNodes)
++                .set({ endpoint })
++                .where(ne(exitNodes.endpoint, endpoint));
++        }
+         await db
+             .update(exitNodes)
+             .set({ listenPort })

--- a/apps/pangolin/tests.yaml
+++ b/apps/pangolin/tests.yaml
@@ -1,0 +1,42 @@
+# Container Structure Test (schemaVersion present => CST, not GOSS).
+# Structural only: the runtime needs a live Postgres + config, absent in the CI
+# build sandbox, so we assert the EE build produced the expected artifacts (the
+# patched server bundle, migrations, CLI, static assets) rather than booting it.
+schemaVersion: "2.0.0"
+
+fileExistenceTests:
+  - name: server bundle
+    path: /app/dist/server.mjs
+    shouldExist: true
+  - name: migrations bundle
+    path: /app/dist/migrations.mjs
+    shouldExist: true
+  - name: cli bundle
+    path: /app/dist/cli.mjs
+    shouldExist: true
+    permissions: "-rwxr-xr-x"
+  - name: pangctl wrapper
+    path: /usr/local/bin/pangctl
+    shouldExist: true
+    permissions: "-rwxr-xr-x"
+  - name: next standalone server
+    path: /app/server.js
+    shouldExist: true
+  - name: node_modules
+    path: /app/node_modules
+    shouldExist: true
+  - name: public assets
+    path: /app/public
+    shouldExist: true
+
+commandTests:
+  - name: node runtime present
+    command: node
+    args: ["--version"]
+    exitCode: 0
+  - name: patched enterprise build marker
+    # The enterprise build writes server/build.ts => build == "enterprise";
+    # confirm the deterministic-subdomain helper made it into the bundle.
+    command: sh
+    args: ["-c", "grep -q deterministicExitNodeLabel /app/dist/server.mjs"]
+    exitCode: 0


### PR DESCRIPTION
## What

New app `apps/pangolin/` — [Pangolin](https://github.com/fosrl/pangolin) **Enterprise (postgresql)** rebuilt from the pinned upstream tag with a two-file patch series that makes exit-node **subdomains deterministic** instead of random.

## Why

With `use_subdomain: true`, stock Pangolin assigns each exit node a **random** `adjective-animal` label that only exists *after* the gerbil registers — so you can't pre-create its DNS record, which forces the EE dynamic authoritative-DNS component. We run static, operator-named HA exit nodes (`gerbil01/02/03` → `png01/02/03`) and want to pre-create the DNS ourselves. This fork derives the label from the gerbil's own `reachableAt` host.

## Patches (applied with `git apply`, fail the build loudly on upstream drift)

| Patch | File | Change |
|-------|------|--------|
| 0001 | `server/private/routers/gerbil/createExitNode.ts` (EE) | `subEndpoint` = first host label of `reachableAt` (`http://png01:3004` → `png01`); upstream random name as fallback. |
| 0002 | `server/setup/copyInConfig.ts` | `copyInConfig` runs on **every** boot (`server/index.ts:37` → `runSetupFunctions` → `copyInConfig`) and resets endpoints to `base_endpoint`; with `use_subdomain` on, skip that reset so `png0N` labels survive restarts. |

## Build

Mirrors upstream's own Dockerfile (`BUILD=enterprise`, `DATABASE=pg`, same Next.js + esbuild pipeline); source fetched at `${VERSION}` in-image, patches applied, compiled ourselves. `git apply` fails the build on any drift from the pinned version.

## Validation (local)

- `docker buildx bake --load` green, container-structure-test **9/9**.
- Includes a `grep deterministicExitNodeLabel /app/dist/server.mjs` test — proves the patch compiled into the shipped bundle (esbuild `minify:false`).

## Note

`server/private/**` is Fossorial's proprietary Enterprise source; built/run under our Enterprise license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)