### PR TITLE
feat(newt-swarm): bump to upstream 1.14.0

### DIFF
--- a/apps/newt-swarm/docker-bake.hcl
+++ b/apps/newt-swarm/docker-bake.hcl
@@ -1,23 +1,23 @@
 target "docker-metadata-action" {}
 
 # VERSION must match the upstream Newt release this image is built on top of
-# (currently 1.13.0). Used for both the image tag and the binary's internal
+# (currently 1.14.0). Used for both the image tag and the binary's internal
 # version string. Suffixes like -swarm.0 fail upstream's strict X.Y.Z parser
 # in updates/updates.go and would print an error on every start; the
 # patched-build provenance lives in the image name (newt-swarm) and the OCI
 # labels (org.opencontainers.image.revision = SOURCE_REF below) instead.
 variable "VERSION" {
-  default = "1.13.0"
+  default = "1.14.0"
 }
 
 # SOURCE_REF is the git ref (branch, tag, or SHA) on the fork to build from.
-# Pinned to a SHA on swarm-discovery-stable (= upstream tag 1.13.0 + our
+# Pinned to a SHA on swarm-discovery-stable (= upstream tag 1.14.0 + our
 # single feature commit, ported to the moby/moby Docker SDK). This isolates
 # the swarm-discovery change against a known-good release; the dev-based
 # branch on the fork is for the upstream PR only. Bump this SHA when rebasing
 # onto a newer upstream tag.
 variable "SOURCE_REF" {
-  default = "9ca94f1d164c135ec6561580e47243c8c9adcd07"
+  default = "64e6146bb74fe71e9da2aa39c5aa74a513f041fe"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
## What

Bump `newt-swarm` from upstream Newt `1.13.0` → `1.14.0`.

- `VERSION` `1.13.0` → `1.14.0`
- `SOURCE_REF` → `64e6146bb74fe71e9da2aa39c5aa74a513f041fe` (head of `swarm-discovery-stable` on the fork; **parent = upstream annotated tag `1.14.0`** = `527edc8d`, verified via GitHub API)

## Provenance verified

- Feature commit `64e6146` is the single *cluster-wide Swarm service discovery* commit, sitting directly on `fosrl/newt@1.14.0`.
- Build source is the pinned SHA on `mrkhachaturov/newt` (immutable); published artifact is `ghcr.io/astrateam-net/newt-swarm` under the org.
- Note: the fork commit body still reads "Ported to upstream 1.13.0" — stale wording only; actual base is 1.14.0 (rewriting it would change the SHA).

## Test plan

- PR CI builds the changed app (no push).
- Merge to `main` publishes `:1.14.0`, `:1.14`, `:1`, `:rolling`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)