### PR TITLE
feat(flowrunner): n8n task-runner image with _FILE secret support

### DIFF
--- a/apps/flowrunner/Dockerfile
+++ b/apps/flowrunner/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+# check=skip=InvalidDefaultArgInFrom
+
+# n8n task runners (external mode) with *_FILE secret support added. The stock
+# n8nio/runners image — unlike the main n8n image — ignores the *_FILE
+# convention, so docker/1Password secrets can't be file-mounted (the launcher
+# reads N8N_RUNNERS_AUTH_TOKEN from plain env only). Our entrypoint bridges each
+# FOO_FILE -> FOO, then exec's the original tini + launcher (carried in CMD).
+# VERSION from docker-bake.hcl and MUST match the astraflow (n8nio/n8n) version
+# deployed alongside it — the runner protocol is version-locked to the broker.
+
+ARG VERSION
+
+FROM docker.io/n8nio/runners:${VERSION}
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod 0755 /docker-entrypoint.sh
+USER runner
+
+# Bridge runs first, then hands off to the stock entrypoint/cmd via exec "$@".
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/sbin/tini", "--", "/usr/local/bin/task-runner-launcher", "javascript", "python"]

--- a/apps/flowrunner/docker-bake.hcl
+++ b/apps/flowrunner/docker-bake.hcl
@@ -1,0 +1,38 @@
+target "docker-metadata-action" {}
+
+variable "VERSION" {
+  // renovate: datasource=docker depName=docker.io/n8nio/runners
+  default = "2.30.1"
+}
+
+# Our image adds _FILE secret support to stock n8nio/runners — point source at us.
+variable "SOURCE" {
+  default = "https://github.com/astrateam-net/containers"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}

--- a/apps/flowrunner/docker-entrypoint.sh
+++ b/apps/flowrunner/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Bridge *_FILE secrets into their plain env vars, then hand off to CMD.
+#
+# The stock n8nio/runners image — unlike the main n8n image — does NOT resolve
+# the *_FILE convention, so docker/1Password secrets can't be file-mounted (the
+# launcher reads N8N_RUNNERS_AUTH_TOKEN from plain env only). For each FOO_FILE
+# we export FOO from the file's contents. Idempotent: an already-set FOO wins.
+set -eu
+
+for file_var in $(env | sed -n 's/^\([A-Za-z_][A-Za-z0-9_]*_FILE\)=.*/\1/p'); do
+  base_var=${file_var%_FILE}
+
+  # Don't clobber a value that was passed directly.
+  if [ -n "$(printenv "$base_var" 2>/dev/null || true)" ]; then
+    continue
+  fi
+
+  file_path=$(printenv "$file_var")
+  if [ -n "$file_path" ] && [ -f "$file_path" ]; then
+    export "${base_var}=$(cat "$file_path")"
+    unset "$file_var"
+  fi
+done
+
+exec "$@"

--- a/apps/flowrunner/tests.yaml
+++ b/apps/flowrunner/tests.yaml
@@ -1,0 +1,45 @@
+schemaVersion: "2.0.0"
+
+# The launcher needs a live broker to do real work, so we verify the pieces are
+# in place and that the _FILE bridge actually resolves a secret file into env.
+
+commandTests:
+  - name: entrypoint present and executable
+    command: sh
+    args: ["-lc", "test -x /docker-entrypoint.sh"]
+    exitCode: 0
+
+  - name: launcher present
+    command: sh
+    args: ["-lc", "test -x /usr/local/bin/task-runner-launcher"]
+    exitCode: 0
+
+  - name: tini present
+    command: sh
+    args: ["-lc", "test -x /sbin/tini"]
+    exitCode: 0
+
+  # Run the real entrypoint with a FOO_FILE set and a check command as CMD:
+  # it must export FOO from the file before exec'ing "$@".
+  - name: _FILE bridge resolves secret into env
+    setup:
+      - ["sh", "-lc", "printf topsecret > /tmp/tok"]
+    envVars:
+      - key: FOO_FILE
+        value: /tmp/tok
+    command: /docker-entrypoint.sh
+    args: ["sh", "-lc", "test \"$FOO\" = topsecret"]
+    exitCode: 0
+
+  # An already-set plain var must win over its _FILE sibling.
+  - name: explicit env overrides _FILE
+    setup:
+      - ["sh", "-lc", "printf fromfile > /tmp/tok2"]
+    envVars:
+      - key: BAR_FILE
+        value: /tmp/tok2
+      - key: BAR
+        value: direct
+    command: /docker-entrypoint.sh
+    args: ["sh", "-lc", "test \"$BAR\" = direct"]
+    exitCode: 0


### PR DESCRIPTION
## Problem

The stock `n8nio/runners` image — unlike the main n8n image — does **not** resolve the `*_FILE` convention. Our swarm runner passes `N8N_RUNNERS_AUTH_TOKEN_FILE=/run/secrets/...`, but the launcher only reads `N8N_RUNNERS_AUTH_TOKEN` from plain env. Confirmed live: inside the running runner `N8N_RUNNERS_AUTH_TOKEN` is empty, the launcher is stuck at "Waiting for task broker to be ready", and no runner children spawn. Net effect: every **Code node** (JS/Python) execution has no runner and times out.

## Fix

`flowrunner` wraps `n8nio/runners:2.30.1` with a small entrypoint that bridges each `FOO_FILE` → `FOO` from the file's contents, then `exec`s the stock `tini + task-runner-launcher javascript python` (moved into `CMD`). Idempotent — an explicitly set value wins over its `_FILE` sibling.

On the swarm side this means **no compose hacks**: just swap the runner image and keep `N8N_RUNNERS_AUTH_TOKEN_FILE`, so the token stays an encrypted docker secret.

## Version

Pinned to **2.30.1** to match `astraflow` (n8nio/n8n) — the runner protocol is version-locked to the broker. Renovate tracks `docker.io/n8nio/runners`.

## Tests (`tests.yaml`)

- entrypoint / launcher / tini present
- real bridge: `FOO_FILE` file contents land in `$FOO`
- precedence: an explicit `BAR` overrides `BAR_FILE`

Bridge logic also verified locally against a real 32-byte token (no newline mangling) and passthrough with no `_FILE` vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)