### PR TITLE
fix(astrawiki): patch upstream Docmost MCP list-pagination NaN crash

### DIFF
--- a/apps/astrawiki/agent
+++ b/apps/astrawiki/agent
@@ -97,3 +97,55 @@ if (main.includes("./mcp-oauth/broker")) {
   fs.writeFileSync(mainFile, main);
   console.log("astrawiki: MCP OAuth broker wired into main.js");
 }
+
+// ---- 3. UPSTREAM BUGFIX: MCP list pagination NaN ----------------------------
+// Stock Docmost's MCP list tools call the paginated services WITHOUT a limit
+// (list_child_pages has no limit param at all), so cursor-pagination computes
+// `undefined + 1 = NaN` -> `LIMIT NaN` -> Postgres "invalid input syntax for
+// type bigint: NaN". The HTTP API never hits it because its PaginationOptions
+// DTO defaults limit to 20; the MCP path bypasses that DTO. Two targeted fixes,
+// matching Docmost's own behaviour (not inventing a new limit):
+//   a) cursor-pagination: default perPage to 20 (Docmost's canonical default)
+//      when it isn't a positive integer -> fixes every MCP list tool at once.
+//   b) list_child_pages: expose a `limit` param (min 1 / max 100) and pass it
+//      through, so clients can size the page like the sidebar tree does. Cursor
+//      paging already worked; only the limit knob was missing.
+const FILE_PATCHES = [
+  {
+    file: "database/pagination/cursor-pagination.js",
+    name: "pagination-default-limit",
+    skipIf: "opts.perPage = 20;",
+    needle: "    const rows = await qb.limit(opts.perPage + 1).execute();",
+    replacement:
+      "    if (!Number.isInteger(opts.perPage) || opts.perPage <= 0) opts.perPage = 20;\n    const rows = await qb.limit(opts.perPage + 1).execute();",
+  },
+  {
+    file: "ee/mcp/tools/page.tools.js",
+    name: "list_child_pages-limit-schema",
+    skipIf: "Number of child pages per page",
+    needle: "                .describe('Parent page ID to list children of'),",
+    replacement:
+      "                .describe('Parent page ID to list children of'),\n            limit: v4_1.z.number().int().min(1).max(100).optional().describe('Number of child pages per page (default 20, max 100)'),",
+  },
+  {
+    file: "ee/mcp/tools/page.tools.js",
+    name: "list_child_pages-limit-passthrough",
+    skipIf: "{ cursor: args.cursor, limit: args.limit }",
+    needle: "getSidebarPages(spaceId, { cursor: args.cursor }, args.pageId, user.id, spaceCanEdit)",
+    replacement: "getSidebarPages(spaceId, { cursor: args.cursor, limit: args.limit }, args.pageId, user.id, spaceCanEdit)",
+  },
+];
+
+for (const p of FILE_PATCHES) {
+  const fp = path.join(ROOT, p.file);
+  const src = fs.readFileSync(fp, "utf8");
+  if (p.skipIf && src.includes(p.skipIf)) {
+    console.log(`astrawiki: ${p.name} already applied (skipping)`);
+    continue;
+  }
+  if (!src.includes(p.needle)) {
+    throw new Error(`astrawiki: anchor for ${p.name} not found in ${p.file}`);
+  }
+  fs.writeFileSync(fp, src.split(p.needle).join(p.replacement));
+  console.log(`astrawiki: ${p.name} patched`);
+}

--- a/apps/astrawiki/tests.yaml
+++ b/apps/astrawiki/tests.yaml
@@ -60,6 +60,28 @@ commandTests:
       - "grep -qF './mcp-oauth/broker' /app/apps/server/dist/main.js"
     exitCode: 0
 
+  # Upstream MCP list-pagination NaN fix: default perPage + list_child_pages limit.
+  - name: cursor-pagination default limit applied
+    command: sh
+    args:
+      - "-lc"
+      - "grep -qF 'opts.perPage = 20;' /app/apps/server/dist/database/pagination/cursor-pagination.js"
+    exitCode: 0
+
+  - name: list_child_pages exposes limit param
+    command: sh
+    args:
+      - "-lc"
+      - "grep -qF 'Number of child pages per page' /app/apps/server/dist/ee/mcp/tools/page.tools.js"
+    exitCode: 0
+
+  - name: list_child_pages passes limit through
+    command: sh
+    args:
+      - "-lc"
+      - "grep -qF '{ cursor: args.cursor, limit: args.limit }' /app/apps/server/dist/ee/mcp/tools/page.tools.js"
+    exitCode: 0
+
   # Docker/Swarm secrets: <NAME>_FILE must be resolved into <NAME> before the
   # app command runs. Write a temp secret file and confirm the entrypoint
   # exports its contents, then execs the passed command.


### PR DESCRIPTION
## Problem (upstream Docmost bug — not ours)

Docmost's MCP list tools call the paginated services **without a `limit`**, so the cursor-pagination core does `undefined + 1 = NaN` → `LIMIT NaN` → Postgres `invalid input syntax for type bigint: "NaN"`.

- `list_pages` / `list_child_pages` crash on any call that omits `limit`.
- `list_child_pages` has **no `limit` param at all** → crashes unconditionally (no client-side workaround possible).

The HTTP API never hits this because its `PaginationOptions` DTO defaults `limit = 20`; the MCP tools call the services directly, bypassing that DTO. Reproduces on stock `docmost/docmost:0.95.0` — none of our files (broker / license / wiring) are involved.

### Intent (why 20, not a made-up number)

`list_child_pages` → `pageService.getSidebarPages`, i.e. the sidebar **page-tree loader**. It's deliberately cursor-paginated (default page size **20** via the DTO), not "return all children". So the faithful fix supplies Docmost's own canonical default and lets clients page via cursor.

## Fix (two build-time patches via `agent`)

- **`database/pagination/cursor-pagination.js`**: default `perPage` to `20` when it isn't a positive integer. Fixes every cursor-paginated MCP list tool at once; DTO callers (always pass a valid int) are unaffected.
- **`ee/mcp/tools/page.tools.js`**: expose a `limit` param (int, min 1 / max 100) on `list_child_pages` and pass it through to `getSidebarPages`, so clients can size the page like the sidebar does. Cursor paging already worked; only the limit knob was missing.

Each patch asserts its anchor (build fails loud if upstream moves it) and is idempotent.

## Traversal (for reference)

Clients page by cursor: call → `items` + `meta.nextCursor` / `hasNextPage`; call again with `cursor: <nextCursor>` until `hasNextPage: false`. `limit` sizes each page (≤100); trees >100 still loop the cursor.

## Verification

- Local build + structure tests: **12/12** (3 new: default-limit line, `list_child_pages` limit param, limit passthrough).
- Confirmed in the built image: the default lands immediately before `qb.limit(opts.perPage + 1)`; the `limit` param + passthrough are present in `page.tools.js`.

Separate from the MCP-OAuth work (#405/#406) — independent upstream bugfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)