### PR TITLE
feat(netbox): add NetBox image

### DIFF
--- a/apps/netbox/Dockerfile
+++ b/apps/netbox/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+
+# NetBox = official netbox-docker base + carried plugins (netbox-acls, netbox-branching) + boto3
+# for Cloudflare R2 media. Consumed by the tower repo (stacks/tools/netbox). Versions: docker-bake.hcl.
+ARG VERSION=4.6.4
+ARG NETBOX_DOCKER_VERSION=5.0.1
+FROM netboxcommunity/netbox:v${VERSION}-${NETBOX_DOCKER_VERSION}
+
+ARG NETBOX_ACLS_VERSION
+ARG NETBOX_BRANCHING_VERSION
+
+RUN /usr/local/bin/uv pip install \
+      "netbox-acls==${NETBOX_ACLS_VERSION}" \
+      "netboxlabs-netbox-branching==${NETBOX_BRANCHING_VERSION}" \
+      boto3
+
+# Bake the plugin-enable list (also wraps DATABASES for branching) so collectstatic gathers plugin
+# static assets. The SECRET_KEY here is build-time only; the real key is a Docker secret at runtime.
+COPY configuration/plugins.py /etc/netbox/config/plugins.py
+RUN DEBUG="true" \
+    SECRET_KEY="build-time-only-dummy-not-used-at-runtime-0000000000" \
+    /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py collectstatic --no-input

--- a/apps/netbox/README.md
+++ b/apps/netbox/README.md
@@ -1,0 +1,44 @@
+# netbox
+
+Official [netbox-docker](https://github.com/netbox-community/netbox-docker) image + the two plugins
+carried from the old homelab deploy + `boto3` for Cloudflare R2 media. Published as
+`ghcr.io/astrateam-net/netbox`. Consumed by the **tower** repo (`stacks/tools/netbox`).
+
+## What this adds to the base
+
+- **netbox-acls** — access-list modelling.
+- **netboxlabs-netbox-branching** — git-like branching. **Must be last in `PLUGINS`**; needs
+  `DATABASES` wrapped in `DynamicSchemaDict` + a router. `configuration/plugins.py` imports the
+  env-built `DATABASES` from netbox-docker's `configuration.py` and wraps it, so **no DB password is
+  hardcoded** (unlike the upstream branching-on-docker guide).
+- **boto3** — the AWS SDK the base image doesn't ship; required by django-storages for R2.
+
+`collectstatic` runs at build so the plugins' static assets are baked in. The `SECRET_KEY` used for
+that step is a throwaway — build-time only, never used at runtime (the real key is a Docker secret).
+
+## Dropped in the 4.6 move
+
+| Plugin | Reason |
+|---|---|
+| `nextbox-ui-plugin` | No NetBox 4.6 release (newest, 1.0.7, tops out at 4.1). |
+| `netbox-routing` | Already disabled on the old host; unused. |
+
+## Versions
+
+All pinned in [`docker-bake.hcl`](docker-bake.hcl) (renovate-tracked):
+
+| Variable | Purpose |
+|---|---|
+| `VERSION` | NetBox app version → our published image tag |
+| `NETBOX_DOCKER_VERSION` | netbox-docker packaging version; base tag = `v${VERSION}-${NETBOX_DOCKER_VERSION}` |
+| `NETBOX_ACLS_VERSION` / `NETBOX_BRANCHING_VERSION` | plugin pins (keep NetBox-4.6-compatible) |
+
+## Build
+
+```bash
+docker buildx bake image-local          # local single-arch
+docker buildx bake image-all            # multi-arch (CI)
+```
+
+CI (`.github/workflows/app-builder.yaml`) builds + pushes on release. Structural checks in
+[`tests.yaml`](tests.yaml).

--- a/apps/netbox/configuration/plugins.py
+++ b/apps/netbox/configuration/plugins.py
@@ -1,0 +1,12 @@
+# Baked into the image. See README.md. netbox_branching MUST be last.
+PLUGINS = [
+    "netbox_acls",
+    "netbox_branching",
+]
+
+# Wrap the env-built DATABASES so branching can swap PG schema per branch.
+from netbox.configuration.configuration import DATABASES  # noqa: E402
+from netbox_branching.utilities import DynamicSchemaDict  # noqa: E402
+
+DATABASES = DynamicSchemaDict(DATABASES)
+DATABASE_ROUTERS = ["netbox_branching.database.BranchAwareRouter"]

--- a/apps/netbox/docker-bake.hcl
+++ b/apps/netbox/docker-bake.hcl
@@ -1,0 +1,55 @@
+target "docker-metadata-action" {}
+
+# Base tag = v${VERSION}-${NETBOX_DOCKER_VERSION}; tracked as two independent lines. VERSION drives our tag.
+variable "VERSION" {
+  // renovate: datasource=docker depName=netboxcommunity/netbox extractVersion=^v(?<version>\d+\.\d+\.\d+)$
+  default = "4.6.4"
+}
+
+variable "NETBOX_DOCKER_VERSION" {
+  // renovate: datasource=github-tags depName=netbox-community/netbox-docker
+  default = "5.0.1"
+}
+
+# Carried plugins — must stay NetBox-4.6-compatible. netbox_branching MUST be last in PLUGINS
+# (see configuration/plugins.py). Dropped in the 4.6 move: nextbox-ui (no 4.6 build), netbox-routing.
+variable "NETBOX_ACLS_VERSION" {
+  // renovate: datasource=pypi depName=netbox-acls
+  default = "2.0.1"
+}
+
+variable "NETBOX_BRANCHING_VERSION" {
+  // renovate: datasource=pypi depName=netboxlabs-netbox-branching
+  default = "1.1.1"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/astrateam-net/containers"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION                  = "${VERSION}"
+    NETBOX_DOCKER_VERSION    = "${NETBOX_DOCKER_VERSION}"
+    NETBOX_ACLS_VERSION      = "${NETBOX_ACLS_VERSION}"
+    NETBOX_BRANCHING_VERSION = "${NETBOX_BRANCHING_VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output   = ["type=docker"]
+}
+
+target "image-all" {
+  inherits  = ["image"]
+  platforms = ["linux/amd64", "linux/arm64"]
+}

--- a/apps/netbox/tests.yaml
+++ b/apps/netbox/tests.yaml
@@ -1,0 +1,32 @@
+schemaVersion: "2.0.0"
+
+# Structural only — NetBox needs Postgres + Redis to boot, so we verify the plugins are installed
+# in the venv and the plugin config baked in, rather than running the app.
+
+commandTests:
+  - name: netbox_acls installed
+    command: /opt/netbox/venv/bin/python
+    args: ["-c", "import netbox_acls"]
+    exitCode: 0
+
+  - name: netbox_branching installed
+    command: /opt/netbox/venv/bin/python
+    args: ["-c", "import netbox_branching"]
+    exitCode: 0
+
+  - name: boto3 installed (R2 media)
+    command: /opt/netbox/venv/bin/python
+    args: ["-c", "import boto3"]
+    exitCode: 0
+
+  - name: plugins.py baked in
+    command: sh
+    args: ["-lc", "grep -qF 'netbox_branching' /etc/netbox/config/plugins.py"]
+    exitCode: 0
+
+  - name: branching listed last in PLUGINS
+    command: /opt/netbox/venv/bin/python
+    args:
+      - "-c"
+      - "import ast,io; d=ast.parse(open('/etc/netbox/config/plugins.py').read()); p=[n.value for n in ast.walk(d) if isinstance(n,ast.Assign) and getattr(n.targets[0],'id','')=='PLUGINS'][0]; assert [e.value for e in p.elts][-1]=='netbox_branching'"
+    exitCode: 0


### PR DESCRIPTION
New app `apps/netbox` — official netbox-docker base + carried plugins (`netbox-acls`, `netboxlabs-netbox-branching`) + `boto3` for Cloudflare R2 media. Published as `ghcr.io/astrateam-net/netbox`, consumed by the tower repo.

## Notes
- Base tag is `v${VERSION}-${NETBOX_DOCKER_VERSION}`. The two halves are **independent upstream release lines**, so they're split into two Renovate rules — a combined single tag can't be tracked correctly (docker-versioning pins the suffix; loose/semver drops it to the plain `v4.6.4` tag). `VERSION` (NetBox app version) drives our published tag → clean semver `4.6.4 / 4.6 / 4 / rolling`.
- `configuration/plugins.py` baked in so `collectstatic` gathers plugin assets; `netbox_branching` last in `PLUGINS`, `DATABASES` wrapped in `DynamicSchemaDict` (no hardcoded DB password).

## Verification
Local `mise run local-build netbox` — build OK, all 5 structure tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)