### PR TITLE
feat(netbox): add Diode NetBox plugin

### DIFF
--- a/apps/netbox/Dockerfile
+++ b/apps/netbox/Dockerfile
@@ -1,16 +1,18 @@
 # syntax=docker/dockerfile:1
 
-# NetBox = official netbox-docker base + carried plugins (netbox-acls, netbox-branching) + boto3
-# for Cloudflare R2 media. Consumed by the tower repo (stacks/tools/netbox). Versions: docker-bake.hcl.
+# NetBox = official netbox-docker base + carried plugins (netbox-acls, diode, netbox-branching) +
+# boto3 for Cloudflare R2 media. Consumed by the tower repo (stacks/tools/netbox). Versions: docker-bake.hcl.
 ARG VERSION=4.6.4
 ARG NETBOX_DOCKER_VERSION=5.0.1
 FROM netboxcommunity/netbox:v${VERSION}-${NETBOX_DOCKER_VERSION}
 
 ARG NETBOX_ACLS_VERSION
+ARG NETBOX_DIODE_VERSION
 ARG NETBOX_BRANCHING_VERSION
 
 RUN /usr/local/bin/uv pip install \
       "netbox-acls==${NETBOX_ACLS_VERSION}" \
+      "netboxlabs-diode-netbox-plugin==${NETBOX_DIODE_VERSION}" \
       "netboxlabs-netbox-branching==${NETBOX_BRANCHING_VERSION}" \
       boto3
 

--- a/apps/netbox/README.md
+++ b/apps/netbox/README.md
@@ -7,6 +7,13 @@ carried from the old homelab deploy + `boto3` for Cloudflare R2 media. Published
 ## What this adds to the base
 
 - **netbox-acls** — access-list modelling.
+- **netboxlabs-diode-netbox-plugin** — write-side API for the **Diode ingestion / NetBox Discovery**
+  pipeline (adds `/api/plugins/diode` + the *Diode → Client Credentials* UI). Runs on **safe
+  defaults** (`diode_target = grpc://localhost:8080/diode`, no secret) with **no required settings**,
+  so NetBox boots fine before the Diode server exists — the UI just sits idle. The real gRPC target
+  and `netbox_to_diode` secret are environment-specific and belong in the **tower** stack's runtime
+  `config/extra.py` (`PLUGINS_CONFIG`), added when the Diode server is deployed — not baked here.
+  Ships a migration; the `app` service's entrypoint auto-applies it on boot.
 - **netboxlabs-netbox-branching** — git-like branching. **Must be last in `PLUGINS`**; needs
   `DATABASES` wrapped in `DynamicSchemaDict` + a router. `configuration/plugins.py` imports the
   env-built `DATABASES` from netbox-docker's `configuration.py` and wraps it, so **no DB password is
@@ -31,7 +38,7 @@ All pinned in [`docker-bake.hcl`](docker-bake.hcl) (renovate-tracked):
 |---|---|
 | `VERSION` | NetBox app version → our published image tag |
 | `NETBOX_DOCKER_VERSION` | netbox-docker packaging version; base tag = `v${VERSION}-${NETBOX_DOCKER_VERSION}` |
-| `NETBOX_ACLS_VERSION` / `NETBOX_BRANCHING_VERSION` | plugin pins (keep NetBox-4.6-compatible) |
+| `NETBOX_ACLS_VERSION` / `NETBOX_DIODE_VERSION` / `NETBOX_BRANCHING_VERSION` | plugin pins (keep NetBox-4.6-compatible; Diode ≥ 1.12.0 for 4.6) |
 
 ## Build
 

--- a/apps/netbox/configuration/plugins.py
+++ b/apps/netbox/configuration/plugins.py
@@ -1,6 +1,9 @@
 # Baked into the image. See README.md. netbox_branching MUST be last.
+# netbox_diode_plugin runs on safe defaults (grpc://localhost:8080/diode, no secret) until the
+# Diode server is deployed; runtime PLUGINS_CONFIG lives in the tower stack's config/extra.py.
 PLUGINS = [
     "netbox_acls",
+    "netbox_diode_plugin",
     "netbox_branching",
 ]
 

--- a/apps/netbox/docker-bake.hcl
+++ b/apps/netbox/docker-bake.hcl
@@ -18,6 +18,13 @@ variable "NETBOX_ACLS_VERSION" {
   default = "2.0.1"
 }
 
+# Diode NetBox plugin — write-side API for the Diode ingestion / NetBox Discovery pipeline.
+# NetBox 4.6 requires >= 1.12.0 (plugin min_version 4.4.10 / max_version 4.6.99).
+variable "NETBOX_DIODE_VERSION" {
+  // renovate: datasource=pypi depName=netboxlabs-diode-netbox-plugin
+  default = "1.14.0"
+}
+
 variable "NETBOX_BRANCHING_VERSION" {
   // renovate: datasource=pypi depName=netboxlabs-netbox-branching
   default = "1.1.1"
@@ -37,6 +44,7 @@ target "image" {
     VERSION                  = "${VERSION}"
     NETBOX_DOCKER_VERSION    = "${NETBOX_DOCKER_VERSION}"
     NETBOX_ACLS_VERSION      = "${NETBOX_ACLS_VERSION}"
+    NETBOX_DIODE_VERSION     = "${NETBOX_DIODE_VERSION}"
     NETBOX_BRANCHING_VERSION = "${NETBOX_BRANCHING_VERSION}"
   }
   labels = {

--- a/apps/netbox/tests.yaml
+++ b/apps/netbox/tests.yaml
@@ -9,6 +9,11 @@ commandTests:
     args: ["-c", "import netbox_acls"]
     exitCode: 0
 
+  - name: netbox_diode_plugin installed
+    command: /opt/netbox/venv/bin/python
+    args: ["-c", "import netbox_diode_plugin"]
+    exitCode: 0
+
   - name: netbox_branching installed
     command: /opt/netbox/venv/bin/python
     args: ["-c", "import netbox_branching"]
@@ -22,6 +27,11 @@ commandTests:
   - name: plugins.py baked in
     command: sh
     args: ["-lc", "grep -qF 'netbox_branching' /etc/netbox/config/plugins.py"]
+    exitCode: 0
+
+  - name: diode plugin enabled in plugins.py
+    command: sh
+    args: ["-lc", "grep -qF 'netbox_diode_plugin' /etc/netbox/config/plugins.py"]
     exitCode: 0
 
   - name: branching listed last in PLUGINS


### PR DESCRIPTION
Adds `netboxlabs-diode-netbox-plugin` 1.14.0 to the netbox image — the write-side API for the Diode ingestion / NetBox Discovery pipeline.

- Enabled in `configuration/plugins.py` (inserted before `netbox_branching`, which stays last).
- Runs on safe defaults (`grpc://localhost:8080/diode`, no secret) until the Diode server is deployed; runtime `PLUGINS_CONFIG` lives in the tower stack.
- Version compatible with NetBox 4.6.4 (plugin min 4.4.10 / max 4.6.99) — verified by `collectstatic` at build.

## Verification
Local `mise run local-build netbox` — build OK, all 7 structure tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)