### PR TITLE
fix(renovate): restore docker-bake.hcl version tracking

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -11,7 +11,7 @@
     {
       customType: "regex",
       description: "Process Annotations in Docker Bake",
-      managerFilePatterns: ["(^|/)docker-bake\\.hcl$"],
+      managerFilePatterns: ["/(^|/)docker-bake\\.hcl$/"],
       matchStrings: [
         "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\n.+ = \"(?<currentValue>[^\"]+)\"",
       ],
@@ -45,6 +45,16 @@
       matchUpdateTypes: ["major"],
       automerge: false,
       labels: ["breaking"],
+    },
+    {
+      description: [
+        "Coder (apps/dev) is version-locked to the i18n build — a stray",
+        "bump breaks the русификация patches. Never auto-merge; require",
+        "manual review for every update type.",
+      ],
+      matchFileNames: ["apps/dev/docker-bake.hcl"],
+      automerge: false,
+      labels: ["review-required"],
     },
     {
       description: ["Auto-merge minor/patch GitHub Actions updates"],


### PR DESCRIPTION
## Problem

Renovate has silently tracked **nothing** in `apps/*/docker-bake.hcl` since `9e56d29` (2026-04-09). Every app version bump in the last three months was made by hand — no Renovate PR has touched a bake file since.

Noticed when n8n `2.30.5` (and `2.31.1`) shipped and no PR appeared.

## Root cause

`9e56d29` renamed the deprecated `fileMatch` field to `managerFilePatterns` but kept the value as a bare regex. The two fields do **not** share semantics:

| Field | Accepts |
|---|---|
| `fileMatch` (old) | regex **only** — unwrapped string worked |
| `managerFilePatterns` (new) | regex **or glob** — only regex when wrapped in `/.../` |

Per [`string-pattern-matching.md`](https://docs.renovatebot.com/string-pattern-matching/):
> A valid regex pattern: 1. Starts with `/` or `!/` 2. Ends with `/` or `/i`

So `(^|/)docker-bake\.hcl$` was reinterpreted as a **minimatch glob**, which matches no path. The manager parsed zero files → detected zero deps → raised zero PRs.

## Evidence

1. **Dependency Dashboard** (#1) "Detected Dependencies" lists `docker-compose`, `dockerfile`, `github-actions`, `maven`, `mise`, `npm`, `pip_requirements`, `renovate-config` — **no regex/custom-manager section at all**.
2. **minimatch check** of the old value as a glob:
   ```
   glob "apps/astraflow/docker-bake.hcl" -> false
   glob "apps/astra-sso/docker-bake.hcl" -> false
   glob "docker-bake.hcl"                -> false
   ```
   As regex (new value): `true` for all three.
3. **Timeline** — last Renovate bake PR was 2026-04-04 (#315); config renamed 2026-04-09; every bump since is a manual commit.
4. `renovate-config-validator` passes on the new config.

## Changes

- Wrap the pattern in slashes to restore regex interpretation.
- Exclude `apps/dev` (Coder) from auto-merge — it is version-locked to the i18n build, so an unattended minor/patch bump would break the русификация patches.

## Expected fallout

~15 accumulated bumps will surface as PRs once this merges, most auto-merging per existing rules:

| App | Pinned | Upstream |
|---|---|---|
| astra-sso (authentik) | 2026.5.3 | 2026.5.4 |
| astraflow (n8n) | 2.30.1 | 2.31.1 |
| flowrunner | 2.30.1 | 2.31.1 |
| astrapdf | 2.12.0 | 2.14.2 |
| astrai18n (tolgee) | 3.207.0 | 3.212.1 |
| astravault | 0.161.10 | 0.162.6 |
| astravaultnet | 0.43.100 | 0.43.106 |
| gotenberg | 8.30.1 | 8.34.0 |
| netbox | 4.6.4 | 4.6.5 |
| obsync | 3.5.1 | 3.5.2.1 |
| xtrabackup | 8.4.0-2 | 8.4.0-6.1 |
| postiz | v2.21.8 | v2.21.10 |
| dev-gw | 2026.2.2 | 2026.2.3 |
| n8n-mcp | 2.47.12 | 2.64.1 |
| dev (coder) | v2.34.5 | v2.34.6 — now manual-review only |

Majors (Confluence 11.x, Jira, postgres 18.x) will come through labeled `breaking`, no auto-merge.

### Known follow-up (not fixed here)
`ci-opentofu` is pinned `1.1.0` but annotated `depName=ghcr.io/opentofu/opentofu` (upstream `1.12.4`). Either the annotation points at the wrong thing or the pin is badly drifted — Renovate will attempt `1.1.0 → 1.12.4` once tracking resumes. Worth a separate look.

`newt-swarm` has no Renovate annotation and stays intentionally manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)