### PR TITLE
docs(agents): pin byte-buddy to upstream, stop Renovate moving it

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -57,6 +57,20 @@
       labels: ["review-required"],
     },
     {
+      description: [
+        "byte-buddy is NOT a dependency to keep fresh — it is pinned to match",
+        "the copy each upstream image already ships in /app/lib. The agents",
+        "declare it 'provided', so the jar is never shipped and the JVM loads",
+        "the image's own copy at runtime. A newer version compiles clean (CI",
+        "stays green) but then fails at runtime with NoSuchMethodError, or",
+        "worse, silently no-ops the EE unlock. Newer is WRONG here.",
+        "Re-derive by hand on each upstream bump — see the agent poms.",
+      ],
+      matchManagers: ["maven"],
+      matchPackageNames: ["net.bytebuddy:byte-buddy"],
+      enabled: false,
+    },
+    {
       description: ["Auto-merge minor/patch GitHub Actions updates"],
       matchManagers: ["github-actions"],
       matchUpdateTypes: ["minor", "patch", "pin", "digest"],

--- a/apps/astrai18n/agent/pom.xml
+++ b/apps/astrai18n/agent/pom.xml
@@ -26,7 +26,27 @@
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <!-- Match the version bundled in the tolgee/tolgee image (/app/lib). -->
+    <!--
+      Match the version bundled in the tolgee/tolgee image (/app/lib).
+
+      NOT a dependency to keep fresh — newer is WRONG. Byte Buddy is 'provided'
+      (see the note above), so this jar is never shipped: the JVM loads the
+      image's own copy at runtime. Compiling against a newer API still builds
+      clean, then fails at runtime with NoSuchMethodError — or silently no-ops
+      the unlock. Renovate is disabled for this dep (see .renovaterc.json5).
+
+      Re-derive on every tolgee bump (tolgee declares no explicit byte-buddy,
+      so its Spring Boot BOM governs):
+        1. tolgee-platform gradle.properties -> springBootVersion
+        2. that BOM's <byte-buddy.version>, e.g.
+           repo1.maven.org/maven2/org/springframework/boot/
+             spring-boot-dependencies/<ver>/spring-boot-dependencies-<ver>.pom
+
+      Verified 1.17.8 @ tolgee v3.212.1 (Spring Boot 3.5.14) — 2026-07-15.
+      NB apps/astrapdf pins this separately: it tracks Stirling-PDF, which is on
+      a different Spring Boot line (4.0.x). Both land on 1.17.8 today, but that
+      is coincidence — expect the two pins to diverge, and do not sync them.
+    -->
     <bytebuddy.version>1.17.8</bytebuddy.version>
   </properties>
 

--- a/apps/astrapdf/agent/pom.xml
+++ b/apps/astrapdf/agent/pom.xml
@@ -25,7 +25,29 @@
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <!-- Match the version bundled in the stirling-pdf fat image (/app/lib). -->
+    <!--
+      Match the version bundled in the stirling-pdf fat image (/app/lib).
+
+      NOT a dependency to keep fresh — newer is WRONG. Byte Buddy is 'provided'
+      (see the note above), so this jar is never shipped: the JVM loads the
+      image's own copy at runtime. Compiling against a newer API still builds
+      clean, then fails at runtime with NoSuchMethodError — or silently no-ops
+      the unlock. Renovate is disabled for this dep (see .renovaterc.json5).
+
+      Re-derive on every Stirling-PDF bump (stirling declares no explicit
+      byte-buddy, so its Spring Boot BOM governs):
+        1. Stirling-PDF build.gradle -> springBootVersion
+        2. that BOM's <byte-buddy.version>, e.g.
+           repo1.maven.org/maven2/org/springframework/boot/
+             spring-boot-dependencies/<ver>/spring-boot-dependencies-<ver>.pom
+
+      Verified 1.17.8 @ stirling v2.14.2 (Spring Boot 4.0.6) — 2026-07-15.
+      Boot stays 4.0.6 across v2.12.0/v2.14.0/v2.14.2, so a bump to 2.14.2 needs
+      no change here.
+      NB apps/astrai18n pins this separately: it tracks tolgee, which is on a
+      different Spring Boot line (3.5.x). Both land on 1.17.8 today, but that is
+      coincidence — expect the two pins to diverge, and do not sync them.
+    -->
     <bytebuddy.version>1.17.8</bytebuddy.version>
   </properties>
 


### PR DESCRIPTION
Closes #385.

## Why #385 must not merge

Renovate raised #385 (`byte-buddy 1.17.8 → 1.18.11-jdk5`) against both agent poms, and **CI went green** — which is precisely what makes it dangerous.

Both agents declare byte-buddy `provided`, so the jar is **never shipped**: the JVM loads the copy the upstream image already has in `/app/lib`. The pin's job is to **match that copy**, not to track the newest release.

A newer version compiles clean (provided-scope deps aren't exercised at build time), then at runtime either throws `NoSuchMethodError` or — worse — **silently no-ops the EE unlock**.

## Verification

Derived from each upstream's Spring Boot BOM (neither declares byte-buddy explicitly, so the BOM governs), at the **freshest** tag of each:

| App | Upstream | Tag | Spring Boot | BOM byte-buddy | Our pin |
|---|---|---|---|---|---|
| astrai18n | tolgee-platform | `v3.212.1` | `3.5.14` | **1.17.8** | `1.17.8` ✅ |
| astrapdf | Stirling-PDF | `v2.14.2` | `4.0.6` | **1.17.8** | `1.17.8` ✅ |

Both pins are **already correct**. `1.18.11-jdk5` matches neither — and it's a **Java-5-compat build** while both poms target `release 17`.

Renovate picked it because Maven versioning sorts an unknown qualifier *above* the plain release (`1.18.11-jdk5` > `1.18.11`).

It isn't even early: byte-buddy stays `1.17.8` across stirling `v2.12.0 → v2.14.0 → v2.14.2` (Boot pinned at `4.0.6` throughout).

## Changes

- **`.renovaterc.json5`** — disable Renovate for `net.bytebuddy:byte-buddy`. A code comment can't stop a bot; without this, #385 is re-raised on the next run.
- **both poms** — record why the pin exists, that newer is wrong, and the recipe to re-derive it on each upstream bump (`springBootVersion` → Boot BOM `<byte-buddy.version>`), with the verification date.

**No functional change — the pins are untouched.**

## Note for future bumps

The two pins are **independent**: tolgee is on Boot `3.5.x`, stirling on `4.0.x`. They agree on `1.17.8` today by coincidence. Both poms now say so, to stop anyone syncing them deliberately later.

Useful for the in-flight astrapdf `2.12.0 → 2.14.2` work: **no byte-buddy change needed** — Boot doesn't move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)