### PR TITLE
build(gh-actions-runner): drop arm64, it has no consumer and cannot build

### DIFF
--- a/apps/gh-actions-runner/docker-bake.hcl
+++ b/apps/gh-actions-runner/docker-bake.hcl
@@ -44,10 +44,15 @@ target "image-local" {
   output = ["type=docker"]
 }
 
+# amd64 only — deliberately. This runner is self-hosted on the Synology NAS
+# (x86_64) and there is no arm64 anywhere in the infra, so an arm64 image has no
+# consumer. The arm64 leg was also failing the whole build (arm64 apt pulls from
+# ports.ubuntu.com, which timed out from the hosted arm runner), but that is
+# secondary and may be transient — the reason it is gone is that nothing runs it.
+# Do not re-add until there is an arm64 host in the infra.
 target "image-all" {
   inherits = ["image"]
   platforms = [
-    "linux/amd64",
-    "linux/arm64"
+    "linux/amd64"
   ]
 }


### PR DESCRIPTION
## Why

This runner is **self-hosted on the Synology NAS (x86_64)** and there is **no arm64 anywhere in the infra** — the arm64 image has no consumer. We were spending build time, and lately failing builds, on an artifact nothing runs.

## Secondary: it was also breaking CI

The arm64 leg is what put **#350** (ansible-core) red:

```
Failed to fetch http://ports.ubuntu.com/ubuntu-ports/dists/noble/InRelease
  Could not connect to ports.ubuntu.com:80 — connection timed out
ERROR: process "apt-get -qq update && apt-get -qq install ..." exit code: 100
```

arm64 apt pulls from `ports.ubuntu.com` (amd64 uses `archive.ubuntu.com`). That leg runs on a **GitHub-hosted `ubuntu-24.04-arm`** runner, so this is a mirror-reachability problem on the runner's side and may be transient — **not** a fault in our network. It's secondary anyway: the platform is dropped because nothing consumes it, not because it failed today.

## Effect

- Unblocks **#350** and every future change to this app.
- Halves build time for it.
- Comment records the condition for re-adding (an arm64 host in the infra).

Scoped to `gh-actions-runner` only — every other app keeps `linux/amd64, linux/arm64`.

## Note: this PR is also the canary for #338

Rebased onto `main` **after** #338 (Actions majors: `checkout v7`, `github-script v9`, `setup-node v7`) merged. #338's own CI skipped the app-build matrix, so its majors were never exercised. This PR changes an `apps/**` file, so it runs a **real app build** through the new actions — first genuine test of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)