### PR TITLE
build(ci-opentofu): OpenTofu 1.11.5 → 1.12.4 (latest)

### DIFF
--- a/apps/ci-opentofu/docker-bake.hcl
+++ b/apps/ci-opentofu/docker-bake.hcl
@@ -1,12 +1,16 @@
 target "docker-metadata-action" {}
 
 variable "VERSION" {
-  default = "1.1.0"
+  // This image's own version — not upstream-tracked, so Renovate leaves it
+  // alone. Bump manually whenever the contents change (OPENTOFU_VERSION, the
+  // provider mirror, or the Dockerfile), so the published semver tags point at
+  // new content instead of silently overwriting an existing one.
+  default = "1.2.0"
 }
 
 variable "OPENTOFU_VERSION" {
   // renovate: datasource=docker depName=ghcr.io/opentofu/opentofu
-  default = "1.11.5"
+  default = "1.12.4"
 }
 
 variable "PROXMOX_PROVIDER_VERSION" {


### PR DESCRIPTION
## What

- `OPENTOFU_VERSION` **1.11.5 → 1.12.4** (current latest, released 2026-07-13)
- `VERSION` **1.1.0 → 1.2.0** (this image's own version)

## Why it drifted

Renovate *couldn't* raise this. The docker-bake custom manager was dead from 2026-04-09 until today (fixed in c63b78d), so `OPENTOFU_VERSION` sat at 1.11.5 through the entire 1.12 line. The annotation was correct all along — nothing was reading it.

## Verification

- `1.12.4-minimal` exists on ghcr with **linux/amd64 + linux/arm64**. This matters: the Dockerfile pulls `ghcr.io/opentofu/opentofu:${VERSION}-minimal`, so the plain `1.12.4` tag existing is **not** sufficient.
- Local build passes (**7/7** structure tests).
- Confirmed the built image reports **`OpenTofu v1.12.4`** — the binary, not just the tag.

## Why `VERSION` moves too

`VERSION` is this image's own version and is deliberately **not** upstream-tracked, so Renovate never touches it. Without a manual bump, the new contents would be published **over the existing `1.1.0` / `1.1` / `1` tags**. Added a comment recording that, since it's easy to miss next time.

From here Renovate keeps `OPENTOFU_VERSION` current on its own (minor/patch on `apps/**/docker-bake.hcl` auto-merge), but `VERSION` still needs a hand whenever contents change.

## Not in this PR

`PROXMOX_PROVIDER_VERSION` is `0.100.0` vs **`0.111.1`** upstream — also a victim of the dead manager. Left for Renovate to raise on its own now that it works, since it affects proxmox-foundation consumers and deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)