### PR TITLE
fix(renovate): track ci-ansible's Galaxy collections

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -2,6 +2,14 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>home-operations/renovate-config"],
   ignorePaths: [".archive/**"],
+  // apps/ci-ansible names its Galaxy requirements 'ansible-requirements.yml'.
+  // The ansible-galaxy manager only looks for 'requirements.yml' by default, so
+  // the collections pinned there were never tracked at all — they had drifted up
+  // to two majors behind before anyone noticed. Patterns here are ADDED to the
+  // manager's defaults, they do not replace them.
+  "ansible-galaxy": {
+    managerFilePatterns: ["/(^|/)ansible-requirements\\.ya?ml$/"],
+  },
   // Limit concurrent PRs to avoid noise
   prConcurrentLimit: 5,
   branchConcurrentLimit: 5,


### PR DESCRIPTION
## Problem

`apps/ci-ansible` pins six Galaxy collections in [`ansible-requirements.yml`](apps/ci-ansible/ansible-requirements.yml). **Renovate has never tracked any of them** — not once.

This is **not** the docker-bake breakage (fixed in c63b78d). It's a separate gap that has been there since the file was created.

## Root cause

The `ansible-galaxy` manager only looks for `requirements.yml` by default:

```
pattern:  (^|/)requirements\.ya?ml$
our file: apps/ci-ansible/ansible-requirements.yml   ->  no match
```

The `ansible-` prefix means it never matches, so the manager never runs on the file. Confirmed by the Dependency Dashboard — **no `ansible-galaxy` section** under Detected Dependencies:

```
docker-compose (2), dockerfile (27), github-actions (14), maven (2),
mise (2), npm (5), pip_requirements (1), regex (25), renovate-config (1)
```

## The drift it hid

| Collection | Pinned | Latest | |
|---|---|---|---|
| community.general | `11.4.0` | **`13.2.0`** | 2 majors |
| community.docker | `4.8.2` | **`5.2.1`** | 1 major |
| ansible.posix | `2.1.0` | `2.2.2` | minor |
| onepassword.connect | `2.3.0` | `2.4.0` | minor |
| community.proxmox | `1.6.0` | `2.0.0-beta1` | prerelease — Renovate will skip |
| community.library_inventory_filtering_v1 | `1.1.5` | `1.1.5` | current ✅ |

## Fix

Point the manager at the file rather than renaming it — the name is load-bearing in the Dockerfile:

```dockerfile
COPY ansible-requirements.yml /tmp/ansible-requirements.yml
RUN ansible-galaxy collection install -r /tmp/ansible-requirements.yml
```

Per the docs, these patterns are **added** to the manager's defaults, so a plain `requirements.yml` elsewhere keeps working. Verified: new pattern matches `ansible-requirements.yml` → `true`, plain `requirements.yml` → `false` (already covered by the default).

`renovate-config-validator` passes.

## Fallout

These will **not** auto-merge — our automerge rules are scoped to `apps/**/docker-bake.hcl` and `github-actions`, so they land as review PRs. That's what the two majors want anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)