### PR TITLE
build(ci-opentofu): bpg/proxmox provider 0.100.0 → 0.111.1 (latest)

### DIFF
--- a/apps/ci-opentofu/docker-bake.hcl
+++ b/apps/ci-opentofu/docker-bake.hcl
@@ -5,7 +5,7 @@ variable "VERSION" {
   // alone. Bump manually whenever the contents change (OPENTOFU_VERSION, the
   // provider mirror, or the Dockerfile), so the published semver tags point at
   // new content instead of silently overwriting an existing one.
-  default = "1.2.0"
+  default = "1.3.0"
 }
 
 variable "OPENTOFU_VERSION" {
@@ -15,7 +15,7 @@ variable "OPENTOFU_VERSION" {
 
 variable "PROXMOX_PROVIDER_VERSION" {
   // renovate: datasource=github-releases depName=bpg/terraform-provider-proxmox
-  default = "0.100.0"
+  default = "0.111.1"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
## What

- `PROXMOX_PROVIDER_VERSION` **0.100.0 → 0.111.1** (latest, released 2026-07-03)
- `VERSION` **1.2.0 → 1.3.0**

Another casualty of the dead docker-bake manager (c63b78d) — the mirrored provider sat at 0.100.0 while upstream reached 0.111.1.

## What this fixes — and what it doesn't

The image pre-mirrors the provider so `tofu init` is fast/offline. But `/etc/tofurc` falls back to the registry:

```hcl
provider_installation {
  filesystem_mirror { path = "/usr/share/terraform/providers" }
  direct {}          # <- fallback
}
```

**proxmox-foundation pins `bpg/proxmox` exactly `0.108.0` across all 9 roots**, so the `0.100.0` mirror was *never hit* — every `init` silently fell through to `direct {}` and downloaded from the registry. The mirror has been dead weight, and it fails **silently**, which is why it went unnoticed.

**`0.111.1` does not fix that on its own** (`0.111.1 != 0.108.0`, so fallback still applies). It aligns with the policy that every repo tracks latest: proxmox-foundation gets Renovate next, and when it reaches `0.111.1` the mirror starts working for real.

**No regression meanwhile** — registry fallback is exactly what happens today.

## Verification

- `0.111.1` present on the OpenTofu registry.
- Built image mirrors `terraform-provider-proxmox_0.111.1_linux_amd64.zip` **and** `_linux_arm64.zip`.
- `tofu version` still reports **`OpenTofu v1.12.4`**.

## Why `VERSION` moves

Contents changed, and Renovate never touches `VERSION` (deliberately un-annotated). Without the bump, the new image publishes over the existing `1.2.0` tag.

## ⚠️ Follow-up worth considering

This is the **second** manual `VERSION` bump today. Every Renovate auto-merge of `OPENTOFU_VERSION` / `PROXMOX_PROVIDER_VERSION` changes the image contents but leaves `VERSION` alone — so **auto-merged bumps will silently republish over an existing semver tag**. Under a "Renovate everywhere, always latest" policy that will now happen routinely.

Options: annotate `VERSION` to track OpenTofu directly (so `ci-opentofu:1.12.4` means what it says, and Renovate bumps the tag automatically), or drop semver tags for this image and publish `rolling` only. Consumers already use `:rolling`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)