### PR TITLE
build(ci-ansible): bring Ansible tooling and collections to latest

### DIFF
--- a/apps/ci-ansible/ansible-requirements.yml
+++ b/apps/ci-ansible/ansible-requirements.yml
@@ -1,14 +1,14 @@
 ---
 collections:
   - name: ansible.posix
-    version: "2.1.0"
+    version: "2.2.2"
   - name: community.docker
-    version: "4.8.2"
+    version: "5.2.1"
   - name: community.general
-    version: "11.4.0"
+    version: "13.2.0"
   - name: community.library_inventory_filtering_v1
     version: "1.1.5"
   - name: community.proxmox
-    version: "1.6.0"
+    version: "2.0.0"
   - name: onepassword.connect
-    version: "2.3.0"
+    version: "2.4.0"

--- a/apps/ci-ansible/docker-bake.hcl
+++ b/apps/ci-ansible/docker-bake.hcl
@@ -1,7 +1,7 @@
 target "docker-metadata-action" {}
 
 variable "VERSION" {
-  default = "1.1.0"
+  default = "1.2.0"
 }
 
 variable "ANSIBLE_CORE_VERSION" {
@@ -11,12 +11,12 @@ variable "ANSIBLE_CORE_VERSION" {
 
 variable "PARAMIKO_VERSION" {
   // renovate: datasource=pypi depName=paramiko
-  default = "4.0.0"
+  default = "5.0.0"
 }
 
 variable "ANSIBLE_LINT_VERSION" {
   // renovate: datasource=pypi depName=ansible-lint
-  default = "26.4.0"
+  default = "26.6.0"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
## What

| Dep | From | To | |
|---|---|---|---|
| paramiko | `4.0.0` | **`5.0.0`** | major |
| ansible-lint | `26.4.0` | `26.6.0` | minor |
| ansible.posix | `2.1.0` | `2.2.2` | minor |
| community.docker | `4.8.2` | **`5.2.1`** | major |
| community.general | `11.4.0` | **`13.2.0`** | **two majors** |
| community.proxmox | `1.6.0` | **`2.0.0`** | major |
| onepassword.connect | `2.3.0` | `2.4.0` | minor |
| community.library_inventory_filtering_v1 | `1.1.5` | `1.1.5` | already current |

`VERSION` `1.1.0 → 1.2.0`. ansible-core `2.21.2` landed via #350.

## Why it was stale

Two independent bugs: the docker-bake manager was dead (c63b78d) so the pypi pins never moved, and the Galaxy collections were **never tracked at all** until e33be2c — the `ansible-galaxy` manager doesn't match the `ansible-requirements.yml` filename.

`community.proxmox` goes to **`2.0.0`** — the latest *stable*. Note Galaxy's `highest_version` reports `2.0.0-beta1`, which is a prerelease and wrong to take.

## Verification — four majors, so a green build isn't enough

A successful build only proves the collections *install*. So:

**1. Compatibility with the core we ship (2.21.2):**
```
ansible.posix 2.2.2       requires_ansible >=2.16.0   ✅
community.docker 5.2.1    requires_ansible >=2.17.0   ✅
community.general 13.2.0  requires_ansible >=2.18.0   ✅  <- tightest
community.proxmox 2.0.0   requires_ansible >=2.17.0   ✅
onepassword.connect 2.4.0 requires_ansible >=2.16.0   ✅
library_inventory_filtering_v1 1.1.5  >=2.9.10        ✅
```

**2. Read back what's actually in the built image** (not just the pins):
```
ansible [core 2.21.2]     paramiko 5.0.0     ansible-lint 26.6.0
ansible.posix 2.2.2       community.docker 5.2.1    community.general 13.2.0
community.proxmox 2.0.0   onepassword.connect 2.4.0
community.library_inventory_filtering_v1 1.1.5
```

**3. Every module our playbooks actually call, tested against the new majors** — 9 across control-plane + swarm. All still exist:
```
OK  community.docker.docker_compose_v2 / docker_stack / docker_swarm
OK  community.general.locale_gen / terraform / timezone
OK  onepassword.connect.field_info / generic_item / item_info
```
`item_info` warns its `field` option goes away in onepassword.connect **v3.0.0** — we're going to 2.4.0, and our calls pass `token`/`item`/`vault`, never `field`. Doesn't apply.

## ⚠️ What this still doesn't prove

**This repo's CI never runs a playbook.** A behavioural change inside a major (`community.general` skipping two, `community.proxmox` 1.x→2.0) would surface in **control-plane** or **swarm**, not here. Recommend running a real playbook against `ci-ansible:rolling` before relying on it.

If you'd rather de-risk the bisect, this can be split: minors in one PR, the four majors in another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)