### PR TITLE
build(astrapdf): Stirling-PDF 2.12.0 → 2.14.2

### DIFF
--- a/apps/astrapdf/docker-bake.hcl
+++ b/apps/astrapdf/docker-bake.hcl
@@ -2,7 +2,7 @@ target "docker-metadata-action" {}
 
 variable "VERSION" {
   // renovate: datasource=docker depName=docker.io/stirlingtools/stirling-pdf
-  default = "2.12.0"
+  default = "2.14.2"
 }
 
 # SOURCE_REF is the git ref on our fork carrying the AstraPDF patch set, applied
@@ -11,7 +11,7 @@ variable "VERSION" {
 # branch onto a newer upstream tag, push a new astrapdf-<version> tag, and point
 # this (and VERSION) at it. Drop SOURCE_REF entirely if upstream merges the PR.
 variable "SOURCE_REF" {
-  default = "astrapdf-2.12.0"
+  default = "astrapdf-2.14.2"
 }
 
 # Fork the patched Stirling source is fetched from at build time.


### PR DESCRIPTION
## What

Rebase the AstraPDF patch set onto upstream **2.14.2**.

```
VERSION     2.12.0        -> 2.14.2
SOURCE_REF  astrapdf-2.12.0 -> astrapdf-2.14.2
```

Done by a separate agent, who rebased the fork branch and pushed the tag; committed here on its behalf.

## Why both variables move together

This image builds the app **from our fork at `SOURCE_REF`**, not from the stock upstream image. Bumping `VERSION` alone would build the **old patch set** and silently ship 2.12.0 content labelled 2.14.2.

Renovate only annotates `VERSION`, so **this pair can never be safely auto-merged.** Worth remembering now that the bake manager is live again (c63b78d) and will start raising astrapdf PRs.

## Verified before committing

- **Fork tag exists on the remote:** `refs/tags/astrapdf-2.14.2` → `6e973b0e`. The Dockerfile does `git fetch --depth 1 origin ${SOURCE_REF}` **and** `ADD ${API}/commits/${SOURCE_REF}` for cache-busting — a missing tag fails the build. Both resolve.
- **byte-buddy pin stays `1.17.8`, correctly.** Stirling holds Spring Boot `4.0.6` across v2.12.0 / v2.14.0 / v2.14.2, and that BOM governs byte-buddy (stirling declares none explicitly). Already recorded in the agent pom (988cabec) — **this bump is exactly the case that comment anticipates**, so no change needed here.

## Note

The EE unlock is anchor-based and can degrade to a silent no-op if upstream moved a seam between 2.12.0 and 2.14.2. The agent asserts its anchors, so the build should fail loudly if so — but confirm Enterprise features in a real deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)