### PR TITLE
fix(xtrabackup): use redhat versioning, semver proposes a downgrade

### DIFF
--- a/apps/xtrabackup/docker-bake.hcl
+++ b/apps/xtrabackup/docker-bake.hcl
@@ -1,7 +1,7 @@
 target "docker-metadata-action" {}
 
 variable "VERSION" {
-  // renovate: datasource=docker depName=percona/percona-xtrabackup
+  // renovate: datasource=docker depName=percona/percona-xtrabackup versioning=redhat
   default = "8.4.0-2"
 }
 


### PR DESCRIPTION
## Problem

Renovate had this **queued**:

```
percona/percona-xtrabackup   8.4.0-2 → 8.4.0
```

That's a **downgrade**. Percona tags as `<upstream>-<percona build>`, so `8.4.0-2` is *build 2 of 8.4.0*, and the newest in that line is **`8.4.0-6.1`**:

```
8.4.0-1  8.4.0-2  8.4.0-3  8.4.0-3.1  8.4.0-4  8.4.0-4.1
8.4.0-5  8.4.0-5.1  8.4.0-6  8.4.0-6.1   ← newest
```

Default **semver** reads `-2` as a *prerelease*, concludes `8.4.0 > 8.4.0-2`, and calls it an upgrade.

**It was going to auto-merge.** It types as a patch on `apps/**/docker-bake.hcl`, matching the auto-merge rule — so it would have landed unreviewed, CI green, silently moving xtrabackup back past four builds.

## Picking the scheme — tested, not reasoned

Ran Renovate's own versioning modules against percona's real tag list:

| scheme | proposes from `8.4.0-2` | highest |
|---|---|---|
| `semver` (default) | `8.4.0`, 8.4.0-3 … | **`8.4.0`** ❌ downgrade |
| `docker` | `8.4.0`, **`8.4.0-1`** | `8.4.0` ❌ *worse* |
| `loose` | `8.4.0`, 8.4.0-3 … | `8.4.0` ❌ |
| **`redhat`** | 8.4.0-3 … 8.4.0-6.1 | **`8.4.0-6.1`** ✅ |
| `rpm` / `deb` | same as redhat | `8.4.0-6.1` ✅ |

`redhat` is `<version>-<release>` — exactly percona's scheme.

**Worth flagging:** `versioning=docker` would have made it *worse*, not better — it ranks `8.4.0-1` above `8.4.0-2`. Copying `obsync`'s `versioning=docker` was the obvious guess and would have been wrong. It's right for couchdb's plain semver tags, wrong for these.

## Verified

The custom manager still parses the annotation with `versioning=` present — `matchStrings` captures it as an optional group:

```
{"datasource":"docker","depName":"percona/percona-xtrabackup","versioning":"redhat","currentValue":"8.4.0-2"}
```

After this, Renovate should propose `8.4.0-2 → 8.4.0-6.1` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)