### PR TITLE
build(astrapdf): match app-build Gradle to the fork's wrapper (9.3.1 → 9.6.0)

### DIFF
--- a/apps/astrapdf/Dockerfile
+++ b/apps/astrapdf/Dockerfile
@@ -29,7 +29,9 @@ RUN mvn -q -B -e -DskipTests package
 # Mirrors the fork's docker/embedded/Dockerfile.fat app-build stage, but pulls the source by git ref
 # instead of a build-context COPY. Installs Node + Task because -PbuildWithFrontend=true compiles the
 # React frontend and embeds it into the Spring Boot jar.
-FROM docker.io/library/gradle:9.3.1-jdk25 AS app-build
+# Keep this Gradle version matched to the fork's wrapper: `gradle` is invoked directly below, so the
+# image's Gradle wins over gradle/wrapper/gradle-wrapper.properties. Upstream 2.14.2 builds on 9.6.0.
+FROM docker.io/library/gradle:9.6.0-jdk25 AS app-build
 ARG TASK_VERSION=3.49.1
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates git \


### PR DESCRIPTION
Follow-up to the 2.14.2 bump (#427). Done by a separate agent; committed here on its behalf.

## Why

The app-build stage invokes **`gradle` directly**, not `./gradlew` — so the image's Gradle wins and `gradle/wrapper/gradle-wrapper.properties` is ignored. The Dockerfile pin has to track the fork's wrapper **by hand**.

## Verified (not taken on trust)

```
astrapdf-2.12.0 wrapper -> gradle-9.3.1-bin.zip    (old pin was correct)
astrapdf-2.14.2 wrapper -> gradle-9.6.0-bin.zip    (so 9.6.0 is right)
```

And that the image tag exists: `docker.io/library/gradle:9.6.0-jdk25` → **HTTP 200**, linux/amd64 + arm64.

That last check was worth doing — Docker Hub's tag search surfaces only `9.6.0-jdk25-ubi10` / `-ubi` / `-alpine` for 9.6.0, so it's easy to assume the plain `-jdk25` tag doesn't exist. It does.

## This is a correctness fix, not a build fix

**#427 already built 2.14.2 green on Gradle 9.3.1** — so 9.3.1 *can* compile the 2.14.2 source. This aligns us with the Gradle upstream actually builds and tests with, rather than relying on a newer source tree happening to work on an older Gradle.

## ⚠️ The coupling is now three-way

`VERSION`, `SOURCE_REF`, **and** this Gradle pin all track the fork tag — and **none of it is Renovate-visible**. Renovate annotates only `VERSION`, so an auto-merged astrapdf bump would move `VERSION` alone and leave both the patch set *and* Gradle behind.

**astrapdf should never auto-merge.** Worth an explicit rule, same as `apps/dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)