### PR TITLE
fix(dev-gw): 2026.2.2 → 2026.2.3, re-anchor the pnpm-workspace stub patch

### DIFF
--- a/apps/dev-gw/docker-bake.hcl
+++ b/apps/dev-gw/docker-bake.hcl
@@ -7,7 +7,7 @@ target "docker-metadata-action" {}
 # re-verify patches/ against the new tag (git apply fails the build otherwise).
 variable "VERSION" {
   // renovate: datasource=docker depName=devolutions/devolutions-gateway
-  default = "2026.2.2"
+  default = "2026.2.3"
 }
 
 variable "SOURCE" {

--- a/apps/dev-gw/patches/0002-stub-private-terminal-deps.patch
+++ b/apps/dev-gw/patches/0002-stub-private-terminal-deps.patch
@@ -11,10 +11,13 @@ this edition; RDP — the point of the fork — is fully functional.
 
 --- a/webapp/pnpm-workspace.yaml
 +++ b/webapp/pnpm-workspace.yaml
-@@ -8,3 +8,11 @@ allowBuilds:
+@@ -8,6 +8,14 @@ allowBuilds:
    esbuild: true
    lmdb: true
    msgpackr-extract: true
+ minimumReleaseAge: 1440
+ minimumReleaseAgeExclude:
+   - '@devolutions/*'
 +# devget: private Artifactory-only packages swapped for build stubs (stubs/README.md).
 +# RDP-only edition — stock SSH/Telnet/VNC/ARD sessions and icon glyphs are inert.
 +overrides:


### PR DESCRIPTION
Supersedes #419, which bumped `VERSION` alone and **could not pass**.

## Why #419 failed

```
error: patch failed: webapp/pnpm-workspace.yaml:8
error: webapp/pnpm-workspace.yaml: patch does not apply
```

The webapp is built **from upstream source at the tag and patched**, so `VERSION` and the patches move together. A `VERSION`-only bump breaks the build.

## Cause

`2026.2.3` appends three lines to `webapp/pnpm-workspace.yaml`:

```yaml
  msgpackr-extract: true
+ minimumReleaseAge: 1440
+ minimumReleaseAgeExclude:
+   - '@devolutions/*'
```

Our hunk was `@@ -8,3 +8,11 @@` — it appends `overrides:` at what it assumed was **EOF** after `msgpackr-extract`. It's no longer EOF, so the trailing context doesn't match and `git apply` rejects it.

**Nothing about the override itself was wrong** — only its anchor.

## Fix

Re-anchored to `@@ -8,6 +8,14 @@`, carrying upstream's three new lines as context so our block lands after them. Upstream's `minimumReleaseAge` settings are **preserved untouched**, per the thin-patch rule.

## Verified against the real upstream files

```
v2026.2.3 -> patch applies ✅   (output correct — upstream lines kept, overrides appended)
v2026.2.2 -> rejected ❌        (expected: it's now anchored forward)
```

Result at 2026.2.3:
```yaml
 10  msgpackr-extract: true
 11  minimumReleaseAge: 1440
 12  minimumReleaseAgeExclude:
 13    - '@devolutions/*'
 14  # devget: private Artifactory-only packages swapped for build stubs ...
 16  overrides:
 17    '@devolutions/terminal-shared': 'file:./stubs/terminal-shared'
     ...
```

## This is the design working

The patch failed the build **loudly** rather than silently shipping a webapp with unstubbed private deps.

But it also means **dev-gw can never be auto-merged from a `VERSION` bump alone**. That's now the third app with invisible coupling:

| App | Coupled to `VERSION` | Renovate sees |
|---|---|---|
| **dev-gw** | `patches/*.patch` anchors | `VERSION` only |
| **astrapdf** | `SOURCE_REF` + Gradle pin | `VERSION` only |
| **apps/dev** | i18n patch set | `VERSION` only |

`apps/dev` already has a no-auto-merge rule. **dev-gw and astrapdf should too** — otherwise Renovate will keep raising bumps that can't pass (dev-gw, loudly) or that pass while shipping wrong content (astrapdf, silently).

Closes #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)