### PR TITLE
fix(renovate): parse extractVersion annotations, 5 deps were invisible

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -20,8 +20,14 @@
       customType: "regex",
       description: "Process Annotations in Docker Bake",
       managerFilePatterns: ["/(^|/)docker-bake\\.hcl$/"],
+      // Both trailing options are optional and order-sensitive: versioning=
+      // then extractVersion=, matching how the annotations are written today.
+      // extractVersion is a native regex-manager capture group, so no template
+      // is needed. Without its group here the WHOLE line fails to match (the
+      // regex demands a newline right after depName/versioning), which silently
+      // hid tolgee, infisical, n8n-mcp, netbox and deno from Renovate entirely.
       matchStrings: [
-        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\n.+ = \"(?<currentValue>[^\"]+)\"",
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?\\n.+ = \"(?<currentValue>[^\"]+)\"",
       ],
       datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",


### PR DESCRIPTION
## Problem

Five `docker-bake.hcl` annotations use `extractVersion=` and have **never** been seen by the custom manager — not rate-limited, not queued, simply **absent**:

| App | Pinned | Upstream | Dep |
|---|---|---|---|
| **astrai18n** | `3.207.0` | `3.212.1` | tolgee/tolgee |
| **astravault** | `0.161.10` | `0.162.6` | infisical/infisical |
| n8n-mcp | `2.47.12` | `2.64.1` | czlonkowski/n8n-mcp |
| netbox | `4.6.4` | `4.6.5` | netboxcommunity/netbox |
| obsync | `2.1.4` | — | denoland/deno |

## Root cause

```
datasource=(?<datasource>\S+) depName=(?<depName>\S+)( versioning=(?<versioning>\S+))?\n.+ = "..."
                                                      ^^^^^^^^^^^ optional     ^^ then REQUIRES newline
```

The regex allows an optional ` versioning=` after `depName`, then **requires a newline**. With ` extractVersion=...` sitting there instead, the newline never arrives and the **whole line fails to match**:

```
// renovate: datasource=docker depName=tolgee/tolgee extractVersion=^v(?<version>.+)$
                                                     ^^^^^^^^^^^^^^ regex dies here
```

The dep doesn't show up as *untracked* — it doesn't show up **at all**.

Same silent-absence shape as the two other Renovate bugs found today:
- `managerFilePatterns` regex reinterpreted as a glob (c63b78d)
- `ansible-galaxy` not matching the `ansible-requirements.yml` filename (e33be2c)

**A dep that is never proposed looks exactly like a dep with no updates.** That's why these sat for months.

## Fix

Added an optional `extractVersion` group. It's a **native capture group** for the regex manager, so no `extractVersionTemplate` is needed.

## Verified

Ran both regexes over every annotation in `apps/`:

```
old: 37 matched
new: 42 matched, 0 missed
```

And confirmed the captures are correct:
```
astrai18n   {"datasource":"docker","depName":"tolgee/tolgee","extractVersion":"^v(?<version>.+)$","currentValue":"3.207.0"}
astravault  {"datasource":"docker","depName":"infisical/infisical","extractVersion":"^v(?<version>.+)$","currentValue":"0.161.10"}
obsync      {"datasource":"docker","depName":"couchdb","versioning":"docker","currentValue":"3.5.2"}
obsync      {"datasource":"github-releases","depName":"denoland/deno","extractVersion":"^v(?<version>.*)$","currentValue":"2.1.4"}
xtrabackup  {"datasource":"docker","depName":"percona/percona-xtrabackup","versioning":"redhat","currentValue":"8.4.0-2"}
```

Note `obsync` yields **two** deps from one file (couchdb via `versioning=docker`, deno via `extractVersion`) — my earlier audit only read the first annotation per file and missed the deno one entirely.

`renovate-config-validator` passes.

## ⚠️ Note on astrai18n

Once tracked, Renovate will propose `3.207.0 → 3.212.1`. That app's EE unlock is **anchor-fragile** (silent no-op if upstream renames `EnabledFeaturesProvider.get`), and it's a minor bump → **auto-merges**. Worth verifying the unlock anchors against 3.212.1 before that lands, or adding it to the no-auto-merge list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)