### PR TITLE
fix(renovate): self-maintaining ci-opentofu tags, group n8n with its runners

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -101,6 +101,22 @@
       enabled: false,
     },
     {
+      description: [
+        "n8n and its task runners are version-locked — the runner protocol is",
+        "tied to the broker, so flowrunner (n8nio/runners) MUST match",
+        "astraflow (n8nio/n8n); apps/flowrunner/Dockerfile says so outright.",
+        "They are separate apps in separate files, so by default Renovate",
+        "raises two independently auto-merging PRs: if one fails CI or is held",
+        "up, the other still lands and the pair drifts, silently breaking the",
+        "runner protocol at runtime. Group them so they always move together,",
+        "or not at all. This coupling is across apps, so the matchFileNames",
+        "review rule above cannot express it.",
+      ],
+      matchDatasources: ["docker"],
+      matchPackageNames: ["docker.io/n8nio/n8n", "docker.io/n8nio/runners"],
+      groupName: "n8n",
+    },
+    {
       description: ["Auto-merge minor/patch GitHub Actions updates"],
       matchManagers: ["github-actions"],
       matchUpdateTypes: ["minor", "patch", "pin", "digest"],

--- a/apps/ci-opentofu/docker-bake.hcl
+++ b/apps/ci-opentofu/docker-bake.hcl
@@ -1,14 +1,11 @@
 target "docker-metadata-action" {}
 
+# VERSION is the OpenTofu version, as in every other app here — CI derives the
+# published tags from it, so ci-opentofu:1.12.4 now means what it says, and
+# Renovate moves the tag by moving this. Previously VERSION was this image's own
+# counter and Renovate could not see it, so an auto-merged OpenTofu bump changed
+# the contents while VERSION stood still and republished over an existing tag.
 variable "VERSION" {
-  // This image's own version — not upstream-tracked, so Renovate leaves it
-  // alone. Bump manually whenever the contents change (OPENTOFU_VERSION, the
-  // provider mirror, or the Dockerfile), so the published semver tags point at
-  // new content instead of silently overwriting an existing one.
-  default = "1.3.0"
-}
-
-variable "OPENTOFU_VERSION" {
   // renovate: datasource=docker depName=ghcr.io/opentofu/opentofu
   default = "1.12.4"
 }
@@ -29,7 +26,7 @@ group "default" {
 target "image" {
   inherits = ["docker-metadata-action"]
   args = {
-    VERSION                  = "${OPENTOFU_VERSION}"
+    VERSION                  = "${VERSION}"
     PROXMOX_PROVIDER_VERSION = "${PROXMOX_PROVIDER_VERSION}"
   }
   labels = {


### PR DESCRIPTION
Two gaps that both needed a human to compensate for a tool limitation.

## 1. ci-opentofu published over its own tags

`VERSION` was this image's own counter — deliberately **un-annotated** so Renovate wouldn't touch it — while `OPENTOFU_VERSION` carried the thing that actually changes.

CI derives the published tags from `VERSION`. So an auto-merged OpenTofu bump changed the **contents** while `VERSION` stood still, **republishing new content over an existing `1.x.y` tag**.

I bumped `VERSION` by hand **twice today already**. Under a policy of tracking latest everywhere that becomes routine — and manual discipline is the wrong mechanism.

**Fix:** make `VERSION` the OpenTofu version, as in every other app here:

```hcl
variable "VERSION" {
  // renovate: datasource=docker depName=ghcr.io/opentofu/opentofu
  default = "1.12.4"
}
```

astraflow, astrawiki, astra-sso — all annotate `VERSION` with their upstream dep. ci-opentofu was the odd one out. One source of truth: Renovate moves `VERSION`, the tag moves with the contents, and **`ci-opentofu:1.12.4` now means what it says**.

**Verified** using app-options' own query, not by inspection:
```
docker buildx bake --list type=variables,format=json
  | jq -r '.[] | select(.name == "VERSION") | .value'    -> 1.12.4
```
and rebuilt: image reports `OpenTofu v1.12.4`, mirror holds `0.111.1`.

This is the repo's existing convention, and it accepts that an *overlay* change (provider mirror, Dockerfile) republishes the same tag — exactly as an astraflow agent change does. Consumers pin `:rolling`.

## 2. n8n and its runners could drift apart

`apps/flowrunner/Dockerfile` states it plainly:

> `VERSION ... MUST match the astraflow (n8nio/n8n) version deployed alongside it — the runner protocol is version-locked to the broker.`

But they're separate apps in separate files, so Renovate raised **two independently auto-merging PRs** (#440, #441). I merged those together by hand today — **nothing would have stopped one landing without the other**, silently breaking the protocol at runtime.

**Fix:** `groupName: "n8n"` — they move together or not at all.

This coupling is **across apps**, so the `matchFileNames` review rule from #435 can't express it. And unlike astrapdf/dev-gw, grouping **fixes** it outright rather than deferring to a human.

**Verified** the group catches both, by matching the rule against the real depNames:
```
astraflow   docker.io/n8nio/n8n       -> in group ✅
flowrunner  docker.io/n8nio/runners   -> in group ✅
```

`renovate-config-validator` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)