### PR TITLE
fix(renovate): two deps were parsed then silently dropped

### DIFF
--- a/apps/gerbil-traefik-s6/docker-bake.hcl
+++ b/apps/gerbil-traefik-s6/docker-bake.hcl
@@ -15,7 +15,7 @@ variable "TRAEFIK_VERSION" {
 }
 
 variable "S6_OVERLAY_VERSION" {
-  // renovate: datasource=github-releases depName=just-containers/s6-overlay
+  // renovate: datasource=github-releases depName=just-containers/s6-overlay versioning=loose extractVersion=^v(?<version>.+)$
   default = "3.2.3.0"
 }
 

--- a/apps/vlmcsd/docker-bake.hcl
+++ b/apps/vlmcsd/docker-bake.hcl
@@ -1,7 +1,7 @@
 target "docker-metadata-action" {}
 
 variable "VERSION" {
-  // renovate: datasource=github-tags depName=Wind4/vlmcsd/tags
+  // renovate: datasource=github-tags depName=Wind4/vlmcsd versioning=regex:^svn(?<major>\d+)$
   default = "svn1113"
 }
 


### PR DESCRIPTION
## How this surfaced

Reconciling the Dependency Dashboard's **per-file dep counts** against the annotations actually in the files — they disagreed:

```
gerbil-traefik-s6   dashboard: 2   file has: 3
vlmcsd              dashboard: -   file has: 1    <- listed with NO count at all
```

Both files parse. The **deps were rejected**.

## Root cause

The customManager defaults `versioningTemplate` to **semver**, and neither value is valid semver — so Renovate dropped them without a word:

```
s6-overlay  "3.2.3.0"  4-part  ->  semver=false   (loose=true, docker=true)
vlmcsd      "svn1113"          ->  semver=false, loose=false, docker=false
```

`vlmcsd` also had `depName=Wind4/vlmcsd/tags` — the `/tags` suffix isn't part of the repo name, so `github-tags` couldn't resolve it even if the value had parsed.

## Fixes — picked by testing, not reasoning

Ran Renovate's own versioning modules against the real upstream tags:

| Dep | Fix | Verified |
|---|---|---|
| **s6-overlay** | `versioning=loose` + `extractVersion=^v(?<version>.+)$` (releases are v-prefixed: `v3.2.3.1`, `v3.2.3.0`) | `curValid=true`, finds `3.2.3.1` |
| **vlmcsd** | `depName=Wind4/vlmcsd` + `versioning=regex:^svn(?<major>\d+)$` | `curValid=true`, orders `svn1114 > svn1113` |

**s6-overlay is behind:** `3.2.3.0 → 3.2.3.1`. **vlmcsd** is already on the newest tag (`svn1113`) but was untracked and would have missed the next one.

## Same shape as today's other three — one level deeper

| Bug | What was invisible |
|---|---|
| glob `managerFilePatterns` (c63b78d) | every bake **file** |
| `ansible-galaxy` filename (e33be2c) | the collections **file** |
| `extractVersion` matchStrings (#445) | 5 **annotations** |
| **this** | the file is visible, the **dep** is dropped |

The dashboard's per-file `(N)` count is the **only** place either of these shows.

## Verified

- Annotations still parse with the manager's `matchStrings`, `versioning`/`extractVersion` captured:
```
gerbil-traefik-s6  {"datasource":"github-releases","depName":"just-containers/s6-overlay","versioning":"loose","extractVersion":"^v(?<version>.+)$","currentValue":"3.2.3.0"}
vlmcsd             {"datasource":"github-tags","depName":"Wind4/vlmcsd","versioning":"regex:^svn(?<major>\\d+)$","currentValue":"svn1113"}
```
- Both bake files resolve (`S6_OVERLAY_VERSION = 3.2.3.0`, `VERSION = svn1113`).
- `renovate-config-validator` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)