### PR TITLE
fix(astravault): update infisical (0.162.6 → 0.162.12)

### DIFF
--- a/apps/astravault/docker-bake.hcl
+++ b/apps/astravault/docker-bake.hcl
@@ -2,7 +2,7 @@ target "docker-metadata-action" {}
 
 variable "VERSION" {
   // renovate: datasource=docker depName=infisical/infisical extractVersion=^v(?<version>.+)$
-  default = "0.162.6"
+  default = "0.162.12"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Bumps Infisical EE-unlock image from 0.162.6 to **v0.162.12** (latest release, published 2026-07-23).

## Verification
- Upstream `.upstream/infisical` switched to `v0.162.12`; unlock anchors re-verified:
  - `getDefaultOnPremFeatures` present (`license-fns.ts:65`) — same arrow-fn-returning-object shape the `.mjs` anchors target
  - All 3 numeric CAPS keys present (`auditLogsRetentionDays`, `auditLogStreamLimit`, `honeyTokenLimit`)
  - Feature-flag `: false → : true` sweep still has targets
- `mise run local-build astravault` → patch applied (fail-loud, so a passing build = unlock live), image reports `INFISICAL_PLATFORM_VERSION=v0.162.12`, 4/4 structure tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)