### PR TITLE
fix(dev): host arm64 client binaries for Coder Desktop

### DIFF
--- a/apps/dev/Dockerfile
+++ b/apps/dev/Dockerfile
@@ -30,9 +30,14 @@ ARG VERSION
 # unused Tailscale features (notably the AWS SDK), matching upstream binary size.
 ARG GO_TAGS_COMMON="ts_omit_aws,ts_omit_bird,ts_omit_tap,ts_omit_kube"
 
-# Slim agent/CLI platforms to embed, amd64 only (upstream also ships the arm64
-# and armv7 variants). Space-separated os:arch entries.
-ARG SLIM_OSARCHES="linux:amd64 darwin:amd64 windows:amd64"
+# Slim CLI platforms to embed and serve at /bin/. Coder Desktop and `coder`
+# download the binary matching the CLIENT's os/arch from the server, so we must
+# host every platform a client connects from — notably darwin/arm64 (Apple
+# Silicon). Missing a client's arch leaves it on its bundled older binary and it
+# fails the server version check. Mirrors upstream's matrix except linux/armv7,
+# which needs GOARM handling and a coder-linux-armv7 name this os:arch loop can't
+# emit. Space-separated os:arch entries.
+ARG SLIM_OSARCHES="linux:amd64 linux:arm64 darwin:amd64 darwin:arm64 windows:amd64 windows:arm64"
 
 # --- Stage 1: build the React frontend from pristine upstream ---------------
 FROM --platform=$BUILDPLATFORM docker.io/library/node:22.19.0-bookworm AS site


### PR DESCRIPTION
Coder Desktop / the `coder` CLI download the client binary matching the client's os/arch from the server's `/bin/` endpoint. The `dev` image packed only amd64 slim binaries, so Apple Silicon Macs (and other arm64 clients) had no matching binary and hit `Binary version does not match server`.

Adds linux/darwin/windows **arm64** to `SLIM_OSARCHES` so every client platform is hosted. Server binary stays amd64-only.

Verified: `mise run local-build dev` green (4/4 tests) with all 6 slim arches compiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)