### PR TITLE
feat(astrarag): ship an isolated venv with the MCP SDKs

### DIFF
--- a/apps/astrarag/Dockerfile
+++ b/apps/astrarag/Dockerfile
@@ -12,6 +12,20 @@ COPY --from=upstream /app/src/usage/license/license_public_key.pub ./usage.in
 RUN python patch.py astrarag_public.pem app.in app.out \
  && python patch.py astrarag_public.pem usage.in usage.out
 
+# MCP deps in their own venv: FastMCP needs starlette >=1.0.1, the platform's
+# FastAPI pins <1.0.0. Same base image because a venv is not relocatable — its
+# pyvenv.cfg points at /usr/bin/python3. --no-config and WORKDIR off /app skip
+# upstream's pyproject, which pins resolution to their tailnet package proxy.
+FROM docker.io/llamaindex/llamacloud-backend:${VERSION} AS mcpdeps
+USER root
+WORKDIR /tmp
+COPY --from=ghcr.io/astral-sh/uv:0.11.31 /uv /bin/uv
+COPY mcp-requirements.txt /tmp/mcp-requirements.txt
+RUN ["/bin/uv", "venv", "--no-config", "/opt/mcp/venv", "--python", "/usr/bin/python3"]
+RUN ["/bin/uv", "pip", "install", "--no-config", "--python", "/opt/mcp/venv/bin/python", \
+     "--requirement", "/tmp/mcp-requirements.txt"]
+
 FROM docker.io/llamaindex/llamacloud-backend:${VERSION}
 COPY --from=patcher /w/app.out   /app/src/app/license/license_public_key.pub
 COPY --from=patcher /w/usage.out /app/src/usage/license/license_public_key.pub
+COPY --from=mcpdeps --chown=65532:65532 /opt/mcp/venv /opt/mcp/venv

--- a/apps/astrarag/mcp-requirements.txt
+++ b/apps/astrarag/mcp-requirements.txt
@@ -1,0 +1,12 @@
+# Deps for the MCP venv (/opt/mcp/venv). A file, not a Dockerfile ARG: the image
+# has no shell, so RUN is exec form, which does not expand variables.
+
+# Newest stable; 4.x is prerelease-only. Needs starlette >=1.0.1 — the reason this
+# venv exists at all.
+fastmcp==3.4.5
+
+# Current supported line, not a bump of the 0.1.41 upstream used to ship: different
+# generator, different method names. Covers Index V1+V2, retrieval, parse/classify/
+# extract and job polling. Still raw HTTP for split and pipeline files — this SDK
+# targets the deprecated beta routes there.
+llama-cloud==2.13.0

--- a/apps/astrarag/tests.yaml
+++ b/apps/astrarag/tests.yaml
@@ -7,6 +7,9 @@ fileExistenceTests:
   - name: pubkey usage present
     path: /app/src/usage/license/license_public_key.pub
     shouldExist: true
+  - name: mcp venv interpreter present
+    path: /opt/mcp/venv/bin/python
+    shouldExist: true
 
 fileContentTests:
   - name: expected key present app
@@ -17,3 +20,42 @@ fileContentTests:
     path: /app/src/usage/license/license_public_key.pub
     expectedContents: ["5xcc8kW96LH/D04kvyoA"]
     excludedContents: ['o3G2lxK\+FfE5h2b02JiCStkjopOte4yygDrSkEc8ns50']
+
+# The MCP venv exists to hold dependencies the platform cannot have. These assert
+# the contract rather than exact versions, so a Renovate bump does not turn them
+# red for the wrong reason: FastMCP must import, and the two environments must
+# stay apart. A venv is not relocatable, so a base-image change that moves the
+# interpreter breaks the first test loudly instead of at runtime.
+commandTests:
+  - name: fastmcp imports in the mcp venv
+    command: /opt/mcp/venv/bin/python
+    args: ["-c", "import fastmcp; from fastmcp import FastMCP; FastMCP('probe')"]
+    exitCode: 0
+
+  - name: llama-cloud client imports in the mcp venv
+    command: /opt/mcp/venv/bin/python
+    args:
+      - "-c"
+      - "from llama_cloud import AsyncLlamaCloud; AsyncLlamaCloud(api_key='probe', base_url='http://127.0.0.1:8000')"
+    exitCode: 0
+
+  - name: mcp venv carries starlette 1.x
+    command: /opt/mcp/venv/bin/python
+    args:
+      - "-c"
+      - "import starlette,sys; sys.exit(0 if int(starlette.__version__.split('.')[0]) >= 1 else 1)"
+    exitCode: 0
+
+  - name: platform venv keeps starlette below 1.0
+    command: /app/.venv/bin/python
+    args:
+      - "-c"
+      - "import starlette,sys; sys.exit(0 if int(starlette.__version__.split('.')[0]) < 1 else 1)"
+    exitCode: 0
+
+  - name: platform venv cannot see fastmcp
+    command: /app/.venv/bin/python
+    args:
+      - "-c"
+      - "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('fastmcp') is None else 1)"
+    exitCode: 0


### PR DESCRIPTION
## Why

The MCP addon cannot declare dependencies. It is bind-mounted from `${CONF}` into a distroless image with no shell and no pip, so whatever it needs must already be in the image by luck.

That luck ran out in 0.9.0, which dropped the `llama_cloud` SDK. Nothing in the backend ever imported it — our addon was its only consumer, riding on a transitive dependency. Its V1 pipeline support raises `ModuleNotFoundError` on first use as things stand.

## What

`/opt/mcp/venv`, built at image time:

| package | version | why |
| --- | --- | --- |
| `fastmcp` | 3.4.5 | the current line; the `mcp` SDK only embeds FastMCP 1.0 |
| `llama-cloud` | 2.13.0 | the supported client — covers Index V1 and V2, all four retrieval tools, parse/classify/extract, and job polling |

A separate venv rather than adding to `/app/.venv`, because these genuinely cannot share the platform's interpreter: FastMCP needs `starlette>=1.0.1`, the platform's FastAPI 0.128.8 pins `starlette<1.0.0`. Two majors cannot coexist in one process — two venvs in one image can.

Verified on the built image:

```
/opt/mcp/venv   starlette 1.3.1   fastmcp 3.4.5, llama-cloud 2.13.0
/app/.venv      starlette 0.52.1  fastapi 0.128.8  (untouched)
```

## Three details that each cost a build

- **The stage runs on the same base image.** A venv is not relocatable — `pyvenv.cfg` names `/usr/bin/python3`, which no `python:*` builder provides.
- **`RUN` is exec form throughout.** There is no shell to parse the string form, which is also why versions live in `mcp-requirements.txt` rather than `ARG`s (exec form does not expand variables). Renovate handles requirements files natively.
- **`--no-config` is required.** Upstream's `/app/pyproject.toml` makes their internal tailnet package proxy the sole index, and `uv` honours it from the working directory. Build-time only — there is no pip or uv at runtime, so the stock image never reaches that host.

## Tests

4 → 10, asserting the contract rather than exact versions so a Renovate bump does not turn them red for the wrong reason: both SDKs import, and the two environments stay isolated in both directions. Existing licence-key assertions unchanged and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)