### PR TITLE
fix(deps): take coder v2.35.3, gateway 2026.2.4 and n8n 2.32.7

### DIFF
--- a/apps/astraflow/docker-bake.hcl
+++ b/apps/astraflow/docker-bake.hcl
@@ -2,7 +2,7 @@ target "docker-metadata-action" {}
 
 variable "VERSION" {
   // renovate: datasource=docker depName=docker.io/n8nio/n8n
-  default = "2.31.1"
+  default = "2.32.7"
 }
 
 variable "SOURCE" {

--- a/apps/dev-gw/docker-bake.hcl
+++ b/apps/dev-gw/docker-bake.hcl
@@ -7,7 +7,7 @@ target "docker-metadata-action" {}
 # re-verify patches/ against the new tag (git apply fails the build otherwise).
 variable "VERSION" {
   // renovate: datasource=docker depName=devolutions/devolutions-gateway
-  default = "2026.2.3"
+  default = "2026.2.4"
 }
 
 variable "SOURCE" {

--- a/apps/dev-gw/overlay/webapp/stubs/README.md
+++ b/apps/dev-gw/overlay/webapp/stubs/README.md
@@ -1,6 +1,6 @@
 # Build-only stubs for Devolutions' private npm packages
 
-Five `@devolutions/*` dependencies of `gateway-ui` live on Devolutions' **private**
+Seven `@devolutions/*` dependencies of `gateway-ui` live on Devolutions' **private**
 Artifactory registry (`devolutions.jfrog.io`, auth required — their CI injects
 `ARTIFACTORY_NPM_TOKEN`, see upstream `.github/workflows/ci.yml`) and are not published
 to npmjs:
@@ -8,7 +8,10 @@ to npmjs:
 - `@devolutions/terminal-shared`, `@devolutions/web-ssh-gui`, `@devolutions/web-telnet-gui`
   — the SSH/Telnet terminal components;
 - `@devolutions/iron-remote-desktop-vnc` — the VNC/ARD backend;
-- `@devolutions/icons` — the dvl-icon font + logos.
+- `@devolutions/icons` — the dvl-icon font + logos;
+- `@devolutions/ldap-wasm-js` — the WASM LDAP client (added upstream in 2026.2.4);
+- `@devolutions/web-active-directory-gui` — the Active Directory web client UI
+  (added upstream in 2026.2.4).
 
 Without them a plain `pnpm install` of the webapp workspace 404s, so the stock webapp is
 not buildable outside Devolutions at all. devget only ships the **RDP** launch path, whose
@@ -21,6 +24,11 @@ Consequences in the devget image (all stock-UI-only; the `/launch` route is unaf
 
 - **SSH, Telnet, VNC and ARD web sessions are non-functional** (custom elements/backends
   never materialize).
+- **Active Directory web sessions are non-functional.** `LdapSession.connect` throws, and
+  `WebActiveDirectoryComponent` is dropped from the `WebClientModule` imports array by the
+  override patch — it is a standalone Angular component, a slot only real component metadata
+  can fill. `CUSTOM_ELEMENTS_SCHEMA` keeps `<web-active-directory>` compiling as an unknown
+  element.
 
 **Icons are the exception — they DO render.** The `@devolutions/icons` stub is repopulated at
 build time from the official image of the same pinned version (`tools/harvest-icons.sh`, wired into

--- a/apps/dev-gw/overlay/webapp/stubs/ldap-wasm-js/index.d.ts
+++ b/apps/dev-gw/overlay/webapp/stubs/ldap-wasm-js/index.d.ts
@@ -1,0 +1,29 @@
+// devget build-only stub — see ../README.md.
+// Only the symbols gateway-ui imports; the LDAP request/result shapes stay
+// permissive because nothing in the RDP path constructs them.
+export default function init(): Promise<void>;
+
+export declare function set_logging_level(level: number): void;
+
+export declare const LoggingLevel: Record<string, number>;
+
+export declare class LdapSession {
+    static connect(parameters: LdapSessionParameters): Promise<any>;
+    [key: string]: any;
+}
+
+export declare class LdapSessionParameters {
+    constructor(url: string, decoderMaxBytes?: number);
+    [key: string]: any;
+}
+
+export type Attribute = any;
+export type AttributesArray = any;
+export type BinaryLdapModifies = any;
+export type LdapControl = any;
+export type LdapControlArray = any;
+export type LdapResult = any;
+export type ModifyRequest = any;
+export type SaslBindConfig = any;
+export type SearchParameters = any;
+export type SspiAuthMethod = any;

--- a/apps/dev-gw/overlay/webapp/stubs/ldap-wasm-js/index.js
+++ b/apps/dev-gw/overlay/webapp/stubs/ldap-wasm-js/index.js
@@ -1,0 +1,40 @@
+// devget build-only stub — see ../README.md.
+const unavailable = () => {
+  throw new Error('Active Directory sessions are not available in this build.');
+};
+
+export default function init() {
+  return Promise.resolve();
+}
+
+export function set_logging_level() {}
+
+export const LoggingLevel = Object.freeze({
+  Trace: 0,
+  Debug: 1,
+  Info: 2,
+  Warn: 3,
+  Error: 4,
+  Off: 5,
+});
+
+export const SspiAuthMethod = Object.freeze({
+  Negotiate: 0,
+  Kerberos: 1,
+  Ntlm: 2,
+});
+
+export class LdapSession {
+  static connect = unavailable;
+}
+
+export class LdapSessionParameters {}
+export class Attribute {}
+export class AttributesArray {}
+export class BinaryLdapModifies {}
+export class LdapControl {}
+export class LdapControlArray {}
+export class LdapResult {}
+export class ModifyRequest {}
+export class SaslBindConfig {}
+export class SearchParameters {}

--- a/apps/dev-gw/overlay/webapp/stubs/ldap-wasm-js/package.json
+++ b/apps/dev-gw/overlay/webapp/stubs/ldap-wasm-js/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@devolutions/ldap-wasm-js",
+  "version": "0.3.4",
+  "description": "devget build-only stub — real package is on Devolutions' private registry",
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts"
+}

--- a/apps/dev-gw/overlay/webapp/stubs/web-active-directory-gui/assets/css/_ad-styles.scss
+++ b/apps/dev-gw/overlay/webapp/stubs/web-active-directory-gui/assets/css/_ad-styles.scss
@@ -1,0 +1,2 @@
+/* devget build-only stub — the real file ships the Active Directory web client
+   theme. main.scss @use's it; the AD session type is inert in this build. */

--- a/apps/dev-gw/overlay/webapp/stubs/web-active-directory-gui/index.d.ts
+++ b/apps/dev-gw/overlay/webapp/stubs/web-active-directory-gui/index.d.ts
@@ -1,0 +1,48 @@
+// devget build-only stub — see ../README.md.
+// AdDataProvider/AdSessionManager/AdTranslator/AdUi are `implements` targets, so
+// they must stay interfaces; the rest are annotation-only and stay permissive.
+import { InjectionToken } from '@angular/core';
+
+export declare const AD_DATA_PROVIDER: InjectionToken<unknown>;
+export declare const AD_SESSION_MANAGER: InjectionToken<unknown>;
+export declare const AD_TRANSLATOR: InjectionToken<unknown>;
+export declare const AD_UI: InjectionToken<unknown>;
+
+export declare const AdConnectionEventType: Record<string, string>;
+
+export declare function matchTranslateKey(code: unknown): string;
+export declare function normalizeError(error: unknown): Error;
+
+export interface AdDataProvider {}
+export interface AdSessionManager {}
+export interface AdTranslator {}
+export interface AdUi {}
+
+// gateway-ui derives parameter types from these via Parameters<...>, so the
+// members have to stay callable rather than collapsing to `any`.
+export interface LdapSessionLike {
+    [key: string]: (...args: any[]) => any;
+}
+
+export type ActiveDirectoryConnectionParams = any;
+export type ActiveDirectoryMainHandle = any;
+export type AdAddRequest = any;
+export type AdBindRequest = any;
+export type AdBindResult = any;
+export type AdCapabilities = any;
+export type AdConnectionError = any;
+export type AdDeleteRequest = any;
+export type AdModifyDnRequest = any;
+export type AdModifyRequest = any;
+export type AdPageControl = any;
+export type AdPageResult = any;
+export type AdResult = any;
+export type AdSearchParams = any;
+export type AdSearchResult = any;
+export type AdUiConfirmOptions = any;
+export type AdUiToastOptions = any;
+export type AdWebSessionConfig = any;
+export type LdapControlArrayLike = any;
+export type LdapResultLike = any;
+export type SearchEntryLike = any;
+export type SearchMessageLike = any;

--- a/apps/dev-gw/overlay/webapp/stubs/web-active-directory-gui/index.js
+++ b/apps/dev-gw/overlay/webapp/stubs/web-active-directory-gui/index.js
@@ -1,0 +1,23 @@
+// devget build-only stub — see ../README.md.
+import { InjectionToken } from '@angular/core';
+
+export const AD_DATA_PROVIDER = new InjectionToken('AD_DATA_PROVIDER');
+export const AD_SESSION_MANAGER = new InjectionToken('AD_SESSION_MANAGER');
+export const AD_TRANSLATOR = new InjectionToken('AD_TRANSLATOR');
+export const AD_UI = new InjectionToken('AD_UI');
+
+export const AdConnectionEventType = Object.freeze({
+  Connected: 'Connected',
+  Terminated: 'Terminated',
+  Error: 'Error',
+  Warning: 'Warning',
+  Success: 'Success',
+});
+
+export function matchTranslateKey(code) {
+  return String(code ?? '');
+}
+
+export function normalizeError(error) {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/apps/dev-gw/overlay/webapp/stubs/web-active-directory-gui/package.json
+++ b/apps/dev-gw/overlay/webapp/stubs/web-active-directory-gui/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@devolutions/web-active-directory-gui",
+  "version": "0.0.13",
+  "description": "devget build-only stub — real package is on Devolutions' private registry",
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "peerDependencies": {
+    "@angular/core": ">=20"
+  }
+}

--- a/apps/dev-gw/patches/0002-stub-private-terminal-deps.patch
+++ b/apps/dev-gw/patches/0002-stub-private-terminal-deps.patch
@@ -1,17 +1,24 @@
 Replace Devolutions' private npm packages with build-time stubs.
 
-@devolutions/{terminal-shared,web-ssh-gui,web-telnet-gui,iron-remote-desktop-vnc,icons}
-live on Devolutions' private Artifactory (auth required; upstream CI injects
-ARTIFACTORY_NPM_TOKEN — see .github/workflows/ci.yml) and are NOT on npmjs, so a
-plain `pnpm install` 404s and the stock webapp is unbuildable outside Devolutions.
-devget ships the RDP launch path only, whose deps (iron-remote-desktop[-rdp]) are
-public. The stubs (overlay: webapp/stubs/) export exactly the symbols/files
-gateway-ui imports. SSH/Telnet/VNC/ARD web sessions and icon glyphs are inert in
-this edition; RDP — the point of the fork — is fully functional.
+@devolutions/{terminal-shared,web-ssh-gui,web-telnet-gui,iron-remote-desktop-vnc,
+icons,ldap-wasm-js,web-active-directory-gui} live on Devolutions' private
+Artifactory (auth required; upstream CI injects ARTIFACTORY_NPM_TOKEN — see
+.github/workflows/ci.yml) and are NOT on npmjs, so a plain `pnpm install` 401s and
+the stock webapp is unbuildable outside Devolutions. devget ships the RDP launch
+path only, whose deps (iron-remote-desktop[-rdp]) are public. The stubs (overlay:
+webapp/stubs/) export exactly the symbols/files gateway-ui imports. SSH/Telnet/
+VNC/ARD/Active Directory web sessions and icon glyphs are inert in this edition;
+RDP — the point of the fork — is fully functional.
+
+WebActiveDirectoryComponent is dropped from the WebClientModule imports array
+because it is a standalone Angular component: only real component metadata
+satisfies that slot, which a stub cannot supply. The module declares
+CUSTOM_ELEMENTS_SCHEMA, so <web-active-directory> in the Active Directory
+template still compiles as an unknown element.
 
 --- a/webapp/pnpm-workspace.yaml
 +++ b/webapp/pnpm-workspace.yaml
-@@ -8,6 +8,14 @@ allowBuilds:
+@@ -8,6 +8,16 @@ allowBuilds:
    esbuild: true
    lmdb: true
    msgpackr-extract: true
@@ -19,10 +26,30 @@ this edition; RDP — the point of the fork — is fully functional.
  minimumReleaseAgeExclude:
    - '@devolutions/*'
 +# devget: private Artifactory-only packages swapped for build stubs (stubs/README.md).
-+# RDP-only edition — stock SSH/Telnet/VNC/ARD sessions and icon glyphs are inert.
++# RDP-only edition — stock SSH/Telnet/VNC/ARD/AD sessions and icon glyphs are inert.
 +overrides:
 +  '@devolutions/terminal-shared': 'file:./stubs/terminal-shared'
 +  '@devolutions/web-ssh-gui': 'file:./stubs/web-ssh-gui'
 +  '@devolutions/web-telnet-gui': 'file:./stubs/web-telnet-gui'
 +  '@devolutions/iron-remote-desktop-vnc': 'file:./stubs/iron-remote-desktop-vnc'
 +  '@devolutions/icons': 'file:./stubs/icons'
++  '@devolutions/ldap-wasm-js': 'file:./stubs/ldap-wasm-js'
++  '@devolutions/web-active-directory-gui': 'file:./stubs/web-active-directory-gui'
+--- a/webapp/apps/gateway-ui/src/client/app/modules/web-client/web-client.module.ts
++++ b/webapp/apps/gateway-ui/src/client/app/modules/web-client/web-client.module.ts
+@@ -2,7 +2,6 @@ import { NgOptimizedImage } from '@angular/common';
+ import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
+ import { FormsModule } from '@angular/forms';
+ import { RouterModule, Routes } from '@angular/router';
+-import { WebActiveDirectoryComponent } from '@devolutions/web-active-directory-gui';
+ import { ArdToolbarWrapperComponent } from '@gateway/modules/web-client/ard/ard-toolbar-wrapper.component';
+ import { WebClientArdComponent } from '@gateway/modules/web-client/ard/web-client-ard.component';
+ import { ActiveDirectoryFormComponent } from '@gateway/modules/web-client/form/form-components/active-directory/active-directory-form.component';
+@@ -75,7 +74,6 @@ const routes: Routes = [
+     ArdToolbarWrapperComponent,
+     RdpToolbarWrapperComponent,
+     VncToolbarWrapperComponent,
+-    WebActiveDirectoryComponent,
+   ],
+   schemas: [CUSTOM_ELEMENTS_SCHEMA],
+   declarations: [

--- a/apps/dev/Dockerfile
+++ b/apps/dev/Dockerfile
@@ -92,7 +92,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
 RUN NODE_ENV=production pnpm build
 
 # --- Stage 2: patch + build slim agents + cross-compile the server ----------
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.4-bookworm AS build
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.5-bookworm AS build
 ARG VERSION
 ARG TARGETOS
 ARG TARGETARCH

--- a/apps/dev/docker-bake.hcl
+++ b/apps/dev/docker-bake.hcl
@@ -6,7 +6,7 @@ target "docker-metadata-action" {}
 # tag (git apply fails the build if a patch no longer matches).
 variable "VERSION" {
   // renovate: datasource=docker depName=ghcr.io/coder/coder
-  default = "v2.35.2"
+  default = "v2.35.3"
 }
 
 variable "SOURCE" {

--- a/apps/flowrunner/docker-bake.hcl
+++ b/apps/flowrunner/docker-bake.hcl
@@ -2,7 +2,7 @@ target "docker-metadata-action" {}
 
 variable "VERSION" {
   // renovate: datasource=docker depName=docker.io/n8nio/runners
-  default = "2.31.1"
+  default = "2.32.7"
 }
 
 # Our image adds _FILE secret support to stock n8nio/runners — point source at us.


### PR DESCRIPTION
Four upstream bumps that Renovate could not land on its own. All built and tested locally.

| app | version | local tests |
|---|---|---|
| dev | v2.35.2 → v2.35.3 | 4/4 pass |
| dev-gw | 2026.2.3 → 2026.2.4 | 5/5 pass |
| astraflow | 2.31.1 → 2.32.7 | 4/4 pass |
| flowrunner | 2.31.1 → 2.32.7 | 4/5 — see below |

**dev** — v2.35.3 raises `go.mod` to `go 1.26.5`, so the pinned `golang:1.26.4-bookworm` build stage failed the module fetch. Bumped to 1.26.5, matching upstream's own `mise.toml`.

**dev-gw** — 2026.2.4 adds an Active Directory web client backed by two more Artifactory-only packages (`ldap-wasm-js`, `web-active-directory-gui`), which 401 on `pnpm install`. Stubbed both, following the five already there. `WebActiveDirectoryComponent` is dropped from the `WebClientModule` imports array — a standalone-component slot needs real component metadata, and `CUSTOM_ELEMENTS_SCHEMA` keeps the element compiling. AD sessions are inert in this RDP-only edition; RDP and the `/launch` route are unaffected and covered by the passing tests.

**astraflow / flowrunner** — 2.32.7 is n8n's stable channel; 2.33.x is tagged prerelease upstream despite the plain-semver tag, so Renovate's 2.33.3 target would pull a beta line. The pair is version-locked by the runner protocol and moves together. Both astraflow unlock anchors (`isLicensed`, `getValue`) still match, and the enterprise/quota gate tests pass.

**flowrunner's one failing local test is pre-existing, not from this bump.** A control build at the currently-shipped 2.31.1 fails the `_FILE bridge resolves secret into env` test identically on the same machine, while CI was green for 2.31.1 on both arches. The runners Dockerfile is byte-identical between the two tags. The divergence is in the local test harness, not the image — tracking it separately; CI is the arbiter here.

Not included: astras3 is left on `RELEASE.2026-06-06` deliberately — its unlock patches raw bytes at hardcoded VAs, so a bump needs a fresh reverse, not a version edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)