### PR TITLE
feat(astrarag): install every fastmcp extra, tasks included

### DIFF
--- a/apps/astrarag/mcp-requirements.txt
+++ b/apps/astrarag/mcp-requirements.txt
@@ -1,4 +1,10 @@
-fastmcp==4.0.0b1
+# Every extra fastmcp ships, not only the ones in use today. The expensive part
+# of adding one is not its bytes, it is that a new dependency needs an image
+# built here and a version bump over in swarm, while anything already installed
+# is a ${CONF} edit away. tasks is the one we need now — background execution
+# via the io.modelcontextprotocol/tasks extension, for tool calls that outrun a
+# caller's patience; the rest are inert until something imports them.
+fastmcp[anthropic,apps,azure,code-mode,gemini,openai,tasks]==4.0.0b1
 fastmcp-slim[client]==4.0.0b1
 llama-cloud==2.13.0
 redis==8.0.1


### PR DESCRIPTION
Installs every extra `fastmcp` ships in the astrarag MCP image, so a new extra costs a `${CONF}` edit rather than an image build plus a swarm digest bump.

`tasks` is the one needed now — background execution via the `io.modelcontextprotocol/tasks` extension, for tool calls that outlast a blocking request. The rest are inert until imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)