### PR TITLE
fix(container): update image infisical/infisical (0.162.15 → 0.162.16)

### DIFF
--- a/apps/astravault/docker-bake.hcl
+++ b/apps/astravault/docker-bake.hcl
@@ -2,7 +2,7 @@ target "docker-metadata-action" {}
 
 variable "VERSION" {
   // renovate: datasource=docker depName=infisical/infisical extractVersion=^v(?<version>.+)$
-  default = "0.162.15"
+  default = "0.162.16"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Bumps astravault to upstream v0.162.16.

Upstream removes the SSH and Agent Sentinel (AI MCP) products; migration `20260729150000_drop-ssh-and-ai-mcp-tables` drops those tables and has an empty `down()`. Take a database backup before deploying.

Entitlement patch anchors verified against the 0.162.16 bundle; local build and tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)