### PR TITLE
feat(astravault): S3-compatible endpoint for PAM recording storage

### DIFF
--- a/apps/astravault/Dockerfile
+++ b/apps/astravault/Dockerfile
@@ -24,6 +24,11 @@ WORKDIR /backend
 COPY patch-entitlements.mjs /tmp/astravault-patch-entitlements.mjs
 RUN node /tmp/astravault-patch-entitlements.mjs && rm /tmp/astravault-patch-entitlements.mjs
 
+# PAM session recordings: honour PAM_RECORDING_S3_ENDPOINT so an S3-compatible provider
+# can back external storage. Same fail-loud contract as the entitlement patch.
+COPY patch-s3-endpoint.mjs /tmp/astravault-patch-s3-endpoint.mjs
+RUN node /tmp/astravault-patch-s3-endpoint.mjs && rm /tmp/astravault-patch-s3-endpoint.mjs
+
 # File-secret support: the upstream image reads config only from plain env vars. Wrap
 # its standalone-entrypoint.sh to resolve <VAR>_FILE (Docker/Swarm secrets in
 # /run/secrets) into the environment first; the wrapper ends with

--- a/apps/astravault/patch-s3-endpoint.mjs
+++ b/apps/astravault/patch-s3-endpoint.mjs
@@ -1,0 +1,55 @@
+// astravault — let PAM session-recording storage target an S3-compatible provider.
+//
+// Upstream builds its S3 client from the per-template recording config alone, which
+// carries bucket/region/keyPrefix but no endpoint, so the SDK always resolves an
+// amazonaws.com host. This rewrites buildClient() in
+// dist/ee/services/pam-session-recording/aws-s3/aws-s3-provider-factory.mjs to honour
+// PAM_RECORDING_S3_ENDPOINT, which is instance-wide: bucket, region, key prefix and the
+// AWS connection stay per-template and keep using the stock UI and API.
+//
+// When the endpoint is set the signing region is overridden too (R2 wants "auto"), since
+// the template's region field is a fixed AWS enum upstream. The template region is still
+// what selects credentials from the app connection, which only matters for STS
+// assume-role; a static access key ignores it.
+//
+//   PAM_RECORDING_S3_ENDPOINT          e.g. https://<account>.r2.cloudflarestorage.com
+//   PAM_RECORDING_S3_REGION            signing region, default "auto"
+//   PAM_RECORDING_S3_FORCE_PATH_STYLE  "false" to use virtual-host style, default path style
+//
+// Unset endpoint leaves the stock AWS behaviour byte-for-byte. Anchored on the S3Client
+// construction; if upstream changes that shape the build FAILS rather than silently
+// shipping an image that ignores the endpoint.
+import { readFileSync, writeFileSync } from "node:fs";
+
+const FILE = "/backend/dist/ee/services/pam-session-recording/aws-s3/aws-s3-provider-factory.mjs";
+
+// buildClient()'s constructor call. `region: config.region` is the first key upstream sets
+// and is what the endpoint path has to override.
+const ANCHOR = /return new S3Client\(\{(\s*)region: config\.region,/;
+
+const REPLACEMENT = `const astravaultS3Endpoint = process.env.PAM_RECORDING_S3_ENDPOINT;
+  return new S3Client({$1...(astravaultS3Endpoint
+      ? {
+          endpoint: astravaultS3Endpoint,
+          forcePathStyle: process.env.PAM_RECORDING_S3_FORCE_PATH_STYLE !== "false"
+        }
+      : {}),$1region: astravaultS3Endpoint ? process.env.PAM_RECORDING_S3_REGION || "auto" : config.region,`;
+
+const src = readFileSync(FILE, "utf8");
+
+const matches = src.match(new RegExp(ANCHOR.source, "g")) ?? [];
+if (matches.length !== 1) {
+  console.error(
+    `astravault: expected exactly 1 S3Client construction in ${FILE}, found ${matches.length} — upstream shape changed; refusing to build`
+  );
+  process.exit(1);
+}
+
+const patched = src.replace(ANCHOR, REPLACEMENT);
+if (patched === src) {
+  console.error("astravault: S3 endpoint substitution did not apply — refusing to build");
+  process.exit(1);
+}
+
+writeFileSync(FILE, patched);
+console.log("astravault: PAM recording S3 endpoint override applied");

--- a/apps/astravault/patch-s3-endpoint.mjs
+++ b/apps/astravault/patch-s3-endpoint.mjs
@@ -12,6 +12,10 @@
 // what selects credentials from the app connection, which only matters for STS
 // assume-role; a static access key ignores it.
 //
+// FIPS is forced off on that path: the S3 endpoint ruleset rejects the combination
+// outright ("A custom endpoint cannot be combined with FIPS"), which would fail every
+// upload and presign. Stock AWS storage keeps whatever crypto.isFipsModeEnabled() reports.
+//
 //   PAM_RECORDING_S3_ENDPOINT          e.g. https://<account>.r2.cloudflarestorage.com
 //   PAM_RECORDING_S3_REGION            signing region, default "auto"
 //   PAM_RECORDING_S3_FORCE_PATH_STYLE  "false" to use virtual-host style, default path style
@@ -23,9 +27,10 @@ import { readFileSync, writeFileSync } from "node:fs";
 
 const FILE = "/backend/dist/ee/services/pam-session-recording/aws-s3/aws-s3-provider-factory.mjs";
 
-// buildClient()'s constructor call. `region: config.region` is the first key upstream sets
-// and is what the endpoint path has to override.
-const ANCHOR = /return new S3Client\(\{(\s*)region: config\.region,/;
+// buildClient()'s constructor call. Both keys the endpoint path has to override are part
+// of the anchor, so an upstream change to either one fails the build.
+const ANCHOR =
+  /return new S3Client\(\{(\s*)region: config\.region,\s*useFipsEndpoint: crypto\.isFipsModeEnabled\(\),/;
 
 const REPLACEMENT = `const astravaultS3Endpoint = process.env.PAM_RECORDING_S3_ENDPOINT;
   return new S3Client({$1...(astravaultS3Endpoint
@@ -33,7 +38,7 @@ const REPLACEMENT = `const astravaultS3Endpoint = process.env.PAM_RECORDING_S3_E
           endpoint: astravaultS3Endpoint,
           forcePathStyle: process.env.PAM_RECORDING_S3_FORCE_PATH_STYLE !== "false"
         }
-      : {}),$1region: astravaultS3Endpoint ? process.env.PAM_RECORDING_S3_REGION || "auto" : config.region,`;
+      : {}),$1region: astravaultS3Endpoint ? process.env.PAM_RECORDING_S3_REGION || "auto" : config.region,$1useFipsEndpoint: astravaultS3Endpoint ? false : crypto.isFipsModeEnabled(),`;
 
 const src = readFileSync(FILE, "utf8");
 


### PR DESCRIPTION
PAM session recordings can target an S3-compatible provider (Cloudflare R2) via `PAM_RECORDING_S3_ENDPOINT`.

Upstream builds its S3 client from the per-template recording config, which carries no endpoint, so the SDK always resolves an amazonaws.com host. The three resolvers construct that config by explicit field picking, so widening the template schema alone would not reach the client. The endpoint is instance-wide, so it is read in `buildClient` instead: bucket, region, key prefix and the AWS connection stay per-template and keep the stock UI and API.

- `PAM_RECORDING_S3_ENDPOINT` — provider endpoint
- `PAM_RECORDING_S3_REGION` — signing region, default `auto`
- `PAM_RECORDING_S3_FORCE_PATH_STYLE` — `false` for virtual-host style

Verified in the built image: with the var set the client signs `https://<host>/<bucket>/` under an `auto/s3` scope; unset it signs `https://<bucket>.s3.<region>.amazonaws.com/` exactly as upstream. Local build and tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)