### PR TITLE
chore(astrallm): bump litellm to 1.96.0

### DIFF
--- a/apps/astrallm/docker-bake.hcl
+++ b/apps/astrallm/docker-bake.hcl
@@ -2,7 +2,7 @@ target "docker-metadata-action" {}
 
 variable "VERSION" {
   // renovate: datasource=docker depName=ghcr.io/berriai/litellm
-  default = "1.95.1"
+  default = "1.96.0"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Bumps base to `ghcr.io/berriai/litellm:1.96.0`. Local build + tests green.