### PR TITLE
feat(pangolin): bump to 1.21.1, traefik to v3.7.10

### DIFF
--- a/apps/gerbil-traefik-s6/Dockerfile
+++ b/apps/gerbil-traefik-s6/Dockerfile
@@ -14,8 +14,8 @@
 # image's Swarm service named `gerbil` so `gerbil:3004` / `gerbil:8080` and
 # Gerbil's `--reachableAt` keep resolving for the rest of the stack.
 
-ARG VERSION=1.4.2
-ARG TRAEFIK_VERSION=v3.6.22
+ARG VERSION
+ARG TRAEFIK_VERSION
 
 # Traefik ships a static, CGO-free binary — lift it straight out of the
 # official image.
@@ -27,7 +27,7 @@ FROM traefik:${TRAEFIK_VERSION} AS traefik
 FROM ghcr.io/fosrl/gerbil:${VERSION} AS runner
 
 ARG TARGETARCH
-ARG S6_OVERLAY_VERSION=3.2.3.0
+ARG S6_OVERLAY_VERSION
 
 # ca-certificates: Traefik ACME + badger plugin fetch over HTTPS.
 # xz: busybox tar needs it to unpack the s6-overlay tarballs.

--- a/apps/gerbil-traefik-s6/docker-bake.hcl
+++ b/apps/gerbil-traefik-s6/docker-bake.hcl
@@ -6,12 +6,11 @@ variable "VERSION" {
   default = "1.4.3"
 }
 
-# Traefik binary lifted into the image. Pinned to the 3.6 line to match the
-# proven standalone traefik_config.yml (badger v1.4.1, entrypoints). Let a
-# jump to 3.7.x be a deliberate, separate change.
+# Traefik binary lifted into the image. Tracks the line Pangolin's reference
+# stack pins in its own compose.
 variable "TRAEFIK_VERSION" {
   // renovate: datasource=docker depName=traefik
-  default = "v3.6.22"
+  default = "v3.7.10"
 }
 
 variable "S6_OVERLAY_VERSION" {

--- a/apps/pangolin/Dockerfile
+++ b/apps/pangolin/Dockerfile
@@ -20,7 +20,7 @@
 # Build variant matches the upstream `ee-postgresql` image: BUILD=enterprise,
 # DATABASE=pg. Runner packaging mirrors upstream's own Dockerfile.
 
-ARG VERSION=1.20.0
+ARG VERSION
 ARG NODE_VERSION=24
 
 # ---- fetch pristine upstream source at the tag, apply our patches ----

--- a/apps/pangolin/docker-bake.hcl
+++ b/apps/pangolin/docker-bake.hcl
@@ -5,7 +5,7 @@ target "docker-metadata-action" {}
 # fails at `git apply`).
 variable "VERSION" {
   // renovate: datasource=github-releases depName=fosrl/pangolin
-  default = "1.20.0"
+  default = "1.21.1"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Bumps Pangolin 1.20.0 → 1.21.1 and, with it, the Traefik line in `gerbil-traefik-s6`.

Pangolin's release CI (`install/Makefile`, `.github/workflows/cicd.yml`) injects the latest gerbil and badger tags at build time, and its compose templates pin `traefik:v3.7` — so the components move as a set:

| Component | Before | After |
|---|---|---|
| Pangolin | 1.20.0 | 1.21.1 |
| Traefik | v3.6.22 | v3.7.10 |
| Gerbil | 1.4.3 | 1.4.3 (already latest) |
| s6-overlay | 3.2.3.2 | 3.2.3.2 (already latest) |

Both `apps/pangolin` patches apply clean at tag 1.21.1.

Also drops the hardcoded `ARG VERSION=` / `ARG TRAEFIK_VERSION=` / `ARG S6_OVERLAY_VERSION=` defaults from both Dockerfiles. Renovate only edits `docker-bake.hcl`, so those defaults had gone stale (gerbil `1.4.2`, s6 `3.2.3.0`); bare `ARG`s fed from bake match the rest of `apps/`.

Deploy note, outside this repo: the mounted `traefik_config.yml` pins the badger plugin at v1.4.1. Upstream ships 1.21.x with **badger v1.5.0**, which strips the `p_token` query param for 1.21's persistent share-link tokens.

Local builds green:
- `mise run local-build pangolin` — 9/9 pass
- `mise run local-build gerbil-traefik-s6` — 7/7 pass (traefik reports 3.7.10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)