### PR TITLE
chore(astrallm): bump litellm to 1.97.0-rc.1

### DIFF
--- a/apps/astrallm/docker-bake.hcl
+++ b/apps/astrallm/docker-bake.hcl
@@ -2,7 +2,7 @@ target "docker-metadata-action" {}
 
 variable "VERSION" {
   // renovate: datasource=docker depName=ghcr.io/berriai/litellm
-  default = "1.96.0"
+  default = "1.97.0-rc.1"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Bumps the LiteLLM base from `1.96.0` to `1.97.0-rc.1`. Same digest on `ghcr.io/berriai/litellm` and `docker.litellm.ai/berriai/litellm` (`sha256:76d036d1…`), so the existing ghcr base and the Renovate annotation stay as they are. No stable `1.97.0` tag exists yet.

`mise run local-build astrallm` green — the build-time `selftest.py` passed, so the RSA-PSS verify path and `is_premium()` are unchanged in the rc, and the structure tests still find the venv at `python3.13`.

⚠️ **Tag note:** `.github/actions/app-versions` strips prerelease suffixes (`sanitize()` does `.split('-')[0]`, and the semver regex coerces to `1.97.0`). So this publishes as `1.97.0`, `1.97`, `1` and `rolling` — there is no `-rc.1` tag on the output image, and `rolling` will serve the rc. When stable 1.97.0 ships, Renovate's bump republishes those same tags over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)