### PR TITLE
feat(actions-runner): restore ARC runner image at 2.336.0

### DIFF
--- a/apps/actions-runner/.dockerignore
+++ b/apps/actions-runner/.dockerignore
@@ -1,0 +1,2 @@
+/*
+!Dockerfile

--- a/apps/actions-runner/Dockerfile
+++ b/apps/actions-runner/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+
+ARG VERSION
+FROM ghcr.io/actions/actions-runner:${VERSION}
+ARG TARGETARCH
+
+ENV HOMEBREW_NO_ANALYTICS=1 \
+    HOMEBREW_NO_ENV_HINTS=1 \
+    HOMEBREW_NO_INSTALL_CLEANUP=1
+
+USER root
+
+RUN \
+    apt-get -qq update \
+    && \
+    apt-get -qq install -y --no-install-recommends --no-install-suggests \
+        ca-certificates \
+        jo \
+        moreutils \
+        wget \
+        zstd \
+    && \
+    case "${TARGETARCH}" in \
+        'amd64') apt-get -qq install -y --no-install-recommends --no-install-suggests gcc ;; \
+    esac \
+    && \
+    curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETARCH}" -o /usr/local/bin/yq \
+        && chmod +x /usr/local/bin/yq \
+    && \
+    mkdir -p -m 755 /etc/apt/keyrings \
+        && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        && cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+        && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+        && apt update \
+        && apt install gh -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+USER runner
+
+RUN \
+    case "${TARGETARCH}" in \
+        'amd64') /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" ;; \
+    esac

--- a/apps/actions-runner/docker-bake.hcl
+++ b/apps/actions-runner/docker-bake.hcl
@@ -1,0 +1,37 @@
+target "docker-metadata-action" {}
+
+variable "VERSION" {
+  // renovate: datasource=docker depName=ghcr.io/actions/actions-runner
+  default = "2.336.0"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/actions/runner"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}

--- a/apps/actions-runner/tests.yaml
+++ b/apps/actions-runner/tests.yaml
@@ -1,0 +1,6 @@
+---
+schemaVersion: "2.0.0"
+fileExistenceTests:
+  - name: yq
+    path: /usr/local/bin/yq
+    shouldExist: true


### PR DESCRIPTION
Brings `apps/actions-runner` back from the archive (removed in 6e2f67e21) and pins the base `ghcr.io/actions/actions-runner` to 2.336.0, the latest release. The stale `.dockerignore` (referenced `defaults/` and `entrypoint.sh`, neither of which exist here) is trimmed.

`mise run local-build actions-runner` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)