### PR TITLE
fix(container): update image infisical/infisical (0.162.18 → 0.162.19)

### DIFF
--- a/apps/astravault/docker-bake.hcl
+++ b/apps/astravault/docker-bake.hcl
@@ -2,7 +2,7 @@ target "docker-metadata-action" {}
 
 variable "VERSION" {
   // renovate: datasource=docker depName=infisical/infisical extractVersion=^v(?<version>.+)$
-  default = "0.162.18"
+  default = "0.162.19"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Renovate had this update rate-limited on the Dependency Dashboard, so bumping it directly.

`mise run local-build astravault` is green — the fail-loud entitlement patch applied cleanly and all 5 structure tests pass against `v0.162.19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)