### PR TITLE
feat(cnpg-pg-cron): pg_cron as a CloudNativePG image volume extension

### DIFF
--- a/apps/cnpg-pg-cron/Dockerfile
+++ b/apps/cnpg-pg-cron/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+# check=skip=InvalidDefaultArgInFrom
+
+ARG PG_MAJOR
+ARG DISTRO
+FROM ghcr.io/cloudnative-pg/postgresql:${PG_MAJOR}-minimal-${DISTRO} AS builder
+
+ARG PG_MAJOR
+ARG EXT_VERSION
+
+USER 0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        "postgresql-${PG_MAJOR}-cron=${EXT_VERSION}" \
+    && rm -rf /var/lib/apt/lists/*
+
+# CloudNativePG mounts this image read-only at /extensions/<name> and points
+# extension_control_path at ./share and dynamic_library_path at ./lib, so the
+# layout below is the contract — not a convention we chose.
+# https://cloudnative-pg.io/docs/current/imagevolume_extensions#image-specifications
+FROM scratch
+ARG PG_MAJOR
+ARG EXT_VERSION
+
+COPY --from=builder /usr/share/doc/postgresql-${PG_MAJOR}-cron/copyright /licenses/postgresql-${PG_MAJOR}-cron/
+COPY --from=builder /usr/lib/postgresql/${PG_MAJOR}/lib/pg_cron* /lib/
+COPY --from=builder /usr/share/postgresql/${PG_MAJOR}/extension/pg_cron* /share/extension/
+
+USER 65532:65532
+
+LABEL org.opencontainers.image.description="pg_cron ${EXT_VERSION} as a CloudNativePG image volume extension for PostgreSQL ${PG_MAJOR}"
+LABEL org.opencontainers.image.licenses="PostgreSQL"

--- a/apps/cnpg-pg-cron/docker-bake.hcl
+++ b/apps/cnpg-pg-cron/docker-bake.hcl
@@ -1,0 +1,51 @@
+target "docker-metadata-action" {}
+
+variable "VERSION" {
+  // renovate: datasource=deb depName=postgresql-18-cron repositoryUrl=https://apt.postgresql.org/pub/repos/apt?suite=trixie-pgdg&components=main extractVersion=^(?<version>\d+\.\d+\.\d+)
+  default = "1.6.7"
+}
+
+variable "EXT_VERSION" {
+  // renovate: datasource=deb depName=postgresql-18-cron repositoryUrl=https://apt.postgresql.org/pub/repos/apt?suite=trixie-pgdg&components=main
+  default = "1.6.7-3.pgdg13+1"
+}
+
+// Must match the major version and distro of the operand image the Cluster
+// runs, or the shared library will not load.
+variable "PG_MAJOR" {
+  default = "18"
+}
+
+variable "DISTRO" {
+  default = "trixie"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/astrateam-net/containers"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    PG_MAJOR    = "${PG_MAJOR}"
+    DISTRO      = "${DISTRO}"
+    EXT_VERSION = "${EXT_VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = ["linux/amd64", "linux/arm64"]
+}

--- a/apps/cnpg-pg-cron/tests.yaml
+++ b/apps/cnpg-pg-cron/tests.yaml
@@ -1,0 +1,24 @@
+schemaVersion: "2.0.0"
+
+# The image is FROM scratch, so it has no shell and commandTests cannot run.
+# What matters is the layout CloudNativePG mounts, so assert exactly that.
+fileExistenceTests:
+  - name: shared library is present
+    path: /lib/pg_cron.so
+    shouldExist: true
+
+  - name: extension control file is present
+    path: /share/extension/pg_cron.control
+    shouldExist: true
+
+  - name: base install script is present
+    path: /share/extension/pg_cron--1.0.sql
+    shouldExist: true
+
+  - name: upgrade path to the default version is present
+    path: /share/extension/pg_cron--1.5--1.6.sql
+    shouldExist: true
+
+  - name: licence is retained
+    path: /licenses/postgresql-18-cron/copyright
+    shouldExist: true


### PR DESCRIPTION
## Why

CNPG's operand images do not ship pg_cron — the `standard` images stop at PGAudit, Postgres Failover Slots and pgvector. The community's [`postgres-extensions-containers`](https://github.com/cloudnative-pg/postgres-extensions-containers) catalogue does not publish it either; it covers pgaudit, pg_crash, pg_ivm, pgvector, PostGIS, timescaledb-oss and wal2json. So there is currently no CNPG-native way to get a scheduler inside Postgres.

Needed for Firecrawl's NuQ queue, whose schema registers ~40 `cron.schedule(...)` jobs.

## How

Built from the PGDG Debian package `postgresql-18-cron=1.6.7-3.pgdg13+1`, exactly the way every official CNPG extension image is built, so the shared library matches the operand image's major version, distro and architecture. The `scratch` stage layout is the operator's documented [image specification](https://cloudnative-pg.io/docs/current/imagevolume_extensions#image-specifications) — CNPG mounts the image read-only at `/extensions/<name>` and points `extension_control_path` at `./share`, `dynamic_library_path` at `./lib`.

Built locally for linux/amd64 and unpacked to confirm the layout:

```
lib/pg_cron.so
share/extension/pg_cron.control          # default_version = '1.6'
share/extension/pg_cron--1.0.sql
share/extension/pg_cron--1.5--1.6.sql    # ... and the rest of the upgrade path
licenses/postgresql-18-cron/copyright
```

## Note for consumers

pg_cron is a preload module, not a plain `CREATE EXTENSION` extension. Mounting the image is not enough — the `Cluster` must also carry `pg_cron` in `shared_preload_libraries`, as CNPG's own docs call out. `cron.database_name` must name the database where the jobs live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)