### PR TITLE
feat(gerbil-traefik-s6): bump gerbil to 1.5.0, traefik to v3.7.12

### DIFF
--- a/apps/gerbil-traefik-s6/docker-bake.hcl
+++ b/apps/gerbil-traefik-s6/docker-bake.hcl
@@ -3,14 +3,14 @@ target "docker-metadata-action" {}
 # Primary version = Gerbil. Drives the image tag (semver X.Y.Z / rolling).
 variable "VERSION" {
   // renovate: datasource=docker depName=ghcr.io/fosrl/gerbil
-  default = "1.4.3"
+  default = "1.5.0"
 }
 
 # Traefik binary lifted into the image. Tracks the line Pangolin's reference
 # stack pins in its own compose.
 variable "TRAEFIK_VERSION" {
   // renovate: datasource=docker depName=traefik
-  default = "v3.7.10"
+  default = "v3.7.12"
 }
 
 variable "S6_OVERLAY_VERSION" {


### PR DESCRIPTION
Gerbil 1.4.3 → 1.5.0, Traefik v3.7.10 → v3.7.12. s6-overlay already current.

Gerbil 1.5.0 (single-file change, `main.go`):
- `/router/*` reverse-proxy for the Pangolin 1.22.0 AI gateway (`p-dest-header` / `p-dest-host-header`, SNI override, SSE streaming).
- Firewall: allow inbound 80/443 to the node's own WireGuard IP so tunnel traffic reaches Traefik. Previously everything but established + ICMP was dropped.

Traefik v3.7.12 stays on the `v3.7` line upstream's reference stack pins.

`mise run local-build gerbil-traefik-s6`: 7/7 pass, `traefik version` reports 3.7.12; verified the gerbil binary carries the 1.5.0-only `p-dest-header` string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)